### PR TITLE
Fix lane section predecessor/successor flags and add regression test

### DIFF
--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -1,40 +1,15 @@
 import argparse
 import json
 import os
-import yaml
 
-from ingest.loader import load_all
-from normalize.core import build_centerline
-from topology.core import make_sections, build_lane_topology
-from mapping.core import mark_type_from_division_row
-from writer.xodr_writer import write_xodr
-
-def build_lane_spec(sections, lane_topo, defaults, lane_div_df):
-    """
-    Build simple per-section lane spec:
-      - lanes: from topology hint (no center(0); writer adds it)
-      - width: default constant for now
-      - roadMark: one type per section (solid/broken basic)
-    """
-    lanes_guess = lane_topo.get("lanes_guess") or [-1, 1]
-
-    roadmark_type = "solid"
-    if lane_div_df is not None and len(lane_div_df) > 0:
-        roadmark_type = mark_type_from_division_row(lane_div_df.iloc[0])
-
-    out = []
-    for sec in sections:
-        out.append({
-            "s0": sec["s0"], "s1": sec["s1"],
-            "lanes": lanes_guess,
-            "lane_width": defaults.get("lane_width_m", 3.5),
-            "roadMark": roadmark_type,
-            "predecessor": True,
-            "successor": True,
-        })
-    return out
+from csv2xodr.ingest.loader import load_all
+from csv2xodr.normalize.core import build_centerline
+from csv2xodr.topology.core import make_sections, build_lane_topology
+from csv2xodr.writer.xodr_writer import write_xodr
+from csv2xodr.lane_spec import build_lane_spec
 
 def main():
+    import yaml
     ap = argparse.ArgumentParser()
     ap.add_argument("--input", required=True, help="directory containing CSVs")
     ap.add_argument("--output", required=True, help="path to output .xodr")

--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -1,0 +1,40 @@
+"""Helpers for building per-section lane specifications."""
+
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def build_lane_spec(
+    sections: Iterable[Dict[str, Any]],
+    lane_topo: Optional[Dict[str, Any]],
+    defaults: Dict[str, Any],
+    lane_div_df,
+) -> List[Dict[str, Any]]:
+    """Return metadata for each lane section used by the writer."""
+
+    lanes_guess = (lane_topo or {}).get("lanes_guess") or [-1, 1]
+
+    roadmark_type = "solid"
+    if lane_div_df is not None and len(lane_div_df) > 0:
+        from csv2xodr.mapping.core import mark_type_from_division_row
+
+        roadmark_type = mark_type_from_division_row(lane_div_df.iloc[0])
+
+    sections_list = list(sections)
+    total = len(sections_list)
+
+    out: List[Dict[str, Any]] = []
+    for idx, sec in enumerate(sections_list):
+        has_prev = idx > 0
+        has_next = idx < total - 1
+        out.append(
+            {
+                "s0": sec["s0"],
+                "s1": sec["s1"],
+                "lanes": lanes_guess,
+                "lane_width": defaults.get("lane_width_m", 3.5),
+                "roadMark": roadmark_type,
+                "predecessor": has_prev,
+                "successor": has_next,
+            }
+        )
+    return out

--- a/tests/test_lane_spec_links.py
+++ b/tests/test_lane_spec_links.py
@@ -1,0 +1,72 @@
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from csv2xodr.lane_spec import build_lane_spec
+from csv2xodr.writer.xodr_writer import write_xodr
+
+
+class _Series:
+    def __init__(self, values):
+        self._values = list(values)
+        self.iloc = self
+
+    def __getitem__(self, idx):
+        return self._values[idx]
+
+
+class _SimpleCenterline:
+    def __init__(self, columns):
+        self._columns = {k: list(v) for k, v in columns.items()}
+        lengths = {len(v) for v in self._columns.values()}
+        if len(lengths) != 1:
+            raise ValueError("All columns must have the same length")
+
+    def __len__(self):
+        return len(next(iter(self._columns.values())))
+
+    def __getitem__(self, item):
+        return _Series(self._columns[item])
+
+
+def _make_centerline():
+    return _SimpleCenterline({
+        "s": [0.0, 10.0],
+        "x": [0.0, 10.0],
+        "y": [0.0, 0.0],
+        "hdg": [0.0, 0.0],
+    })
+
+
+def test_lane_spec_flags_and_writer_links(tmp_path):
+    sections = [
+        {"s0": 0.0, "s1": 5.0},
+        {"s0": 5.0, "s1": 10.0},
+    ]
+
+    lane_specs = build_lane_spec(sections, lane_topo={}, defaults={}, lane_div_df=None)
+
+    assert lane_specs[0]["predecessor"] is False
+    assert lane_specs[0]["successor"] is True
+    assert lane_specs[1]["predecessor"] is True
+    assert lane_specs[1]["successor"] is False
+
+    out_file = Path(tmp_path) / "lane_links.xodr"
+    write_xodr(_make_centerline(), sections, lane_specs, out_file)
+
+    root = ET.parse(out_file).getroot()
+    lane_sections = root.find(".//lanes").findall("laneSection")
+
+    first_left_link = lane_sections[0].find("./left/lane/link")
+    assert first_left_link is not None
+    assert first_left_link.find("predecessor") is None
+    assert first_left_link.find("successor") is not None
+
+    last_right_link = lane_sections[-1].find("./right/lane/link")
+    assert last_right_link is not None
+    assert last_right_link.find("predecessor") is not None
+    assert last_right_link.find("successor") is None


### PR DESCRIPTION
## Summary
- move lane spec construction into a dedicated module and only mark predecessors/successors when a section has neighbors
- ensure writer continues to honor the booleans by adding a regression test that inspects generated lane link tags

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb9538ff648327b1f3df03e732257f