### PR TITLE
Filter centerline to longest path

### DIFF
--- a/tests/test_centerline_selection.py
+++ b/tests/test_centerline_selection.py
@@ -1,0 +1,46 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+
+from csv2xodr.normalize.core import build_centerline, latlon_to_local_xy
+
+
+def test_build_centerline_chooses_longest_path():
+    path_a = [
+        (35.0, 135.0),
+        (35.0, 135.0001),
+        (35.0, 135.0002),
+        (35.0, 135.0003),
+    ]
+    path_b = [
+        (35.0005, 135.0),
+        (35.0005, 135.00005),
+        (35.0005, 135.0001),
+    ]
+
+    rows = []
+    for idx in range(max(len(path_a), len(path_b))):
+        if idx < len(path_a):
+            rows.append(("A",) + path_a[idx])
+        if idx < len(path_b):
+            rows.append(("B",) + path_b[idx])
+
+    df = pd.DataFrame(rows, columns=["Path Id", "緯度[deg]", "経度[deg]"])
+
+    center, _ = build_centerline(df, None)
+
+    # Only the four points from path A should remain.
+    assert len(center) == len(path_a)
+
+    lat0 = np.mean([lat for lat, _ in path_a])
+    lon0 = np.mean([lon for _, lon in path_a])
+    ax, ay = latlon_to_local_xy(
+        np.array([lat for lat, _ in path_a]),
+        np.array([lon for _, lon in path_a]),
+        lat0,
+        lon0,
+    )
+    expected_length = float(np.hypot(np.diff(ax), np.diff(ay)).sum())
+
+    assert center["s"].iloc[-1] == pytest.approx(expected_length, rel=1e-6)


### PR DESCRIPTION
## Summary
- filter PROFILETYPE_MPU_LINE_GEOMETRY points to the longest Path Id so the centerline no longer jumps between overlapping polylines
- recompute the origin after filtering and cover the behaviour with a regression test that skips when numpy/pandas are unavailable

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68cba1f1ab78832793308eade779e9d4