### PR TITLE
Select longest line feature for centerline

### DIFF
--- a/csv2xodr/normalize/core.py
+++ b/csv2xodr/normalize/core.py
@@ -28,19 +28,59 @@ def build_centerline(df_line_geo: pd.DataFrame, df_base: pd.DataFrame):
     if df_line_geo is None or len(df_line_geo) == 0:
         raise ValueError("line_geometry CSV is required")
 
-    # choose origin
-    if df_base is not None and len(df_base) > 0:
-        lat0 = float(df_base.filter(like="緯度").iloc[0, 0])
-        lon0 = float(df_base.filter(like="経度").iloc[0, 0])
-    else:
-        lat0 = float(df_line_geo.filter(like="緯度").mean(numeric_only=True))
-        lon0 = float(df_line_geo.filter(like="経度").mean(numeric_only=True))
-
     lat_col = df_line_geo.filter(like="緯度").columns[0]
     lon_col = df_line_geo.filter(like="経度").columns[0]
 
     lat = df_line_geo[lat_col].astype(float).to_numpy()
     lon = df_line_geo[lon_col].astype(float).to_numpy()
+
+    # Some datasets interleave several polylines (different Path Ids, line feature IDs,
+    # etc.) inside the same CSV. Stick to the single longest polyline to avoid
+    # creating self-crossing planViews.
+    approx_lat0 = float(lat[0])
+    approx_lon0 = float(lon[0])
+    grouping_columns = []
+    path_col = _col_like(df_line_geo, "Path")
+    if path_col is not None:
+        grouping_columns.append(path_col)
+    line_feature_col = (
+        _col_like(df_line_geo, "ライン型地物ID")
+        or _col_like(df_line_geo, "Line")
+        or _col_like(df_line_geo, "Feature")
+    )
+    if line_feature_col is not None and line_feature_col not in grouping_columns:
+        grouping_columns.append(line_feature_col)
+
+    candidate_lengths = {}
+    if grouping_columns:
+        for key, group in df_line_geo.groupby(grouping_columns, dropna=True):
+            lat_g = group[lat_col].astype(float).to_numpy()
+            lon_g = group[lon_col].astype(float).to_numpy()
+            if len(lat_g) < 2:
+                continue
+            x_tmp, y_tmp = latlon_to_local_xy(lat_g, lon_g, approx_lat0, approx_lon0)
+            ds = np.hypot(np.diff(x_tmp), np.diff(y_tmp))
+            candidate_lengths[key] = float(ds.sum()) if len(ds) else 0.0
+
+    if candidate_lengths:
+        best_key = max(candidate_lengths, key=candidate_lengths.get)
+        if not isinstance(best_key, tuple):
+            best_key = (best_key,)
+        mask = np.ones(len(df_line_geo), dtype=bool)
+        for col, value in zip(grouping_columns, best_key):
+            series = df_line_geo[col]
+            mask &= series.to_numpy() == value
+        df_line_geo = df_line_geo.loc[mask].reset_index(drop=True)
+        lat = df_line_geo[lat_col].astype(float).to_numpy()
+        lon = df_line_geo[lon_col].astype(float).to_numpy()
+
+    # choose origin
+    if df_base is not None and len(df_base) > 0:
+        lat0 = float(df_base.filter(like="緯度").iloc[0, 0])
+        lon0 = float(df_base.filter(like="経度").iloc[0, 0])
+    else:
+        lat0 = float(np.mean(lat))
+        lon0 = float(np.mean(lon))
 
     x, y = latlon_to_local_xy(lat, lon, lat0, lon0)
 

--- a/tests/test_centerline_selection.py
+++ b/tests/test_centerline_selection.py
@@ -1,0 +1,78 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+
+from csv2xodr.normalize.core import build_centerline, latlon_to_local_xy
+
+
+def test_build_centerline_chooses_longest_path():
+    path_a = [
+        (35.0, 135.0),
+        (35.0, 135.0001),
+        (35.0, 135.0002),
+        (35.0, 135.0003),
+    ]
+    path_b = [
+        (35.0005, 135.0),
+        (35.0005, 135.00005),
+        (35.0005, 135.0001),
+    ]
+
+    rows = []
+    for idx in range(max(len(path_a), len(path_b))):
+        if idx < len(path_a):
+            rows.append(("A",) + path_a[idx])
+        if idx < len(path_b):
+            rows.append(("B",) + path_b[idx])
+
+    df = pd.DataFrame(rows, columns=["Path Id", "緯度[deg]", "経度[deg]"])
+
+    center, _ = build_centerline(df, None)
+
+    # Only the four points from path A should remain.
+    assert len(center) == len(path_a)
+
+    lat0 = np.mean([lat for lat, _ in path_a])
+    lon0 = np.mean([lon for _, lon in path_a])
+    ax, ay = latlon_to_local_xy(
+        np.array([lat for lat, _ in path_a]),
+        np.array([lon for _, lon in path_a]),
+        lat0,
+        lon0,
+    )
+    expected_length = float(np.hypot(np.diff(ax), np.diff(ay)).sum())
+
+    assert center["s"].iloc[-1] == pytest.approx(expected_length, rel=1e-6)
+
+
+def test_build_centerline_chooses_longest_line_feature():
+    shared_path = "A"
+    feature_long = "F1"
+    feature_short = "F2"
+
+    long_points = [
+        (35.0, 135.0),
+        (35.0001, 135.00005),
+        (35.0002, 135.0001),
+    ]
+    short_points = [
+        (35.1, 135.1),
+        (35.10005, 135.10005),
+    ]
+
+    rows = []
+    for idx in range(max(len(long_points), len(short_points))):
+        if idx < len(long_points):
+            rows.append((shared_path, feature_long) + long_points[idx])
+        if idx < len(short_points):
+            rows.append((shared_path, feature_short) + short_points[idx])
+
+    df = pd.DataFrame(
+        rows,
+        columns=["Path Id", "ライン型地物ID", "緯度[deg]", "経度[deg]"],
+    )
+
+    center, _ = build_centerline(df, None)
+
+    assert len(center) == len(long_points)


### PR DESCRIPTION
## Summary
- extend the centerline builder to pick the longest combination of path id and line feature id when multiple polylines are interleaved in the CSV
- recompute the latitude/longitude arrays after filtering to the selected polyline
- cover the new behaviour with a regression test that verifies the longest line feature is chosen

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cba1f1ab78832793308eade779e9d4