### PR TITLE
Fix centerline aggregation for duplicate offsets

### DIFF
--- a/tests/test_centerline_selection.py
+++ b/tests/test_centerline_selection.py
@@ -44,3 +44,37 @@ def test_build_centerline_chooses_longest_path():
     expected_length = float(np.hypot(np.diff(ax), np.diff(ay)).sum())
 
     assert center["s"].iloc[-1] == pytest.approx(expected_length, rel=1e-6)
+
+
+def test_build_centerline_averages_duplicate_offsets():
+    df = pd.DataFrame(
+        {
+            "Path Id": ["A", "A", "A", "A"],
+            "Offset[cm]": [0, 0, 100, 100],
+            "緯度[deg]": [35.0, 35.000001, 35.000002, 35.000003],
+            "経度[deg]": [139.0, 139.000001, 139.000002, 139.000003],
+        }
+    )
+
+    center, _ = build_centerline(df, None)
+
+    # Only unique offsets should remain.
+    assert len(center) == 2
+
+    # Offsets are reported in centimetres, so "s" should use metres.
+    assert center["s"].to_list() == pytest.approx([0.0, 1.0], rel=1e-6)
+
+    lat_avg0 = np.mean([35.0, 35.000001])
+    lon_avg0 = np.mean([139.0, 139.000001])
+    lat_avg1 = np.mean([35.000002, 35.000003])
+    lon_avg1 = np.mean([139.000002, 139.000003])
+
+    xs, ys = latlon_to_local_xy(
+        np.array([lat_avg0, lat_avg1]),
+        np.array([lon_avg0, lon_avg1]),
+        np.mean([lat_avg0, lat_avg1]),
+        np.mean([lon_avg0, lon_avg1]),
+    )
+
+    assert center["x"].to_list() == pytest.approx(xs.tolist(), rel=1e-6)
+    assert center["y"].to_list() == pytest.approx(ys.tolist(), rel=1e-6)


### PR DESCRIPTION
## Summary
- collapse duplicated longitudinal offsets in the line geometry into a single averaged centerline point
- scale cumulative `s` values using provider offsets so the OpenDRIVE centerline no longer weaves across lane boundaries
- add regression coverage ensuring duplicate offsets are averaged to avoid the cross/diamond artefact

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cbac7a3d248327a4a6bb3e60a7ccd0