### PR TITLE
refactor: 移除 pandas 依赖并修复 csv2xodr

### DIFF
--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -16,14 +16,22 @@ from csv2xodr.writer.xodr_writer import write_xodr
 from csv2xodr.lane_spec import build_lane_spec
 
 def main():
-    import yaml
+    try:
+        import yaml  # type: ignore
+    except ModuleNotFoundError:  # pragma: no cover - optional dependency
+        yaml = None
+        from csv2xodr.mini_yaml import load as mini_yaml_load
     ap = argparse.ArgumentParser()
     ap.add_argument("--input", required=True, help="directory containing CSVs")
     ap.add_argument("--output", required=True, help="path to output .xodr")
     ap.add_argument("--config", default="config.yaml")
     args = ap.parse_args()
 
-    cfg = yaml.safe_load(open(args.config, encoding="utf-8"))
+    if yaml is not None:
+        with open(args.config, encoding="utf-8") as fh:
+            cfg = yaml.safe_load(fh)
+    else:
+        cfg = mini_yaml_load(args.config)
     dfs = load_all(args.input, cfg)
 
     # planView (centerline) from line geometry + geo origin

--- a/csv2xodr/ingest/utils.py
+++ b/csv2xodr/ingest/utils.py
@@ -1,13 +1,24 @@
-import pandas as pd
+import csv
+from typing import Iterable
 
-def read_csv_any(path, encodings=("utf-8", "cp932", "gb18030")) -> pd.DataFrame:
+from csv2xodr.simpletable import DataFrame
+
+def _read_with_encoding(path: str, encoding: str) -> DataFrame:
+    with open(path, encoding=encoding, newline="") as fh:
+        reader = csv.DictReader(fh)
+        rows = [row for row in reader]
+    fieldnames: Iterable[str] = reader.fieldnames or []
+    return DataFrame(rows, columns=list(fieldnames))
+
+
+def read_csv_any(path, encodings=("utf-8", "cp932", "gb18030")) -> DataFrame:
     """
     Try multiple encodings to read CSV robustly.
     """
     last_err = None
     for enc in encodings:
         try:
-            return pd.read_csv(path, encoding=enc)
+            return _read_with_encoding(path, enc)
         except Exception as e:
             last_err = e
             continue

--- a/csv2xodr/mapping/core.py
+++ b/csv2xodr/mapping/core.py
@@ -1,6 +1,6 @@
-import pandas as pd
+from csv2xodr.simpletable import Series, notna
 
-def mark_type_from_division_row(row: pd.Series) -> str:
+def mark_type_from_division_row(row: Series) -> str:
     """
     Very rough mapping:
       - if DotLine/破線ペイント is 1 → "broken"
@@ -8,7 +8,7 @@ def mark_type_from_division_row(row: pd.Series) -> str:
       - else "solid"
     """
     for c in row.index:
-        if ("破線" in c or "ペイント" in c) and pd.notna(row[c]):
+        if ("破線" in c or "ペイント" in c) and notna(row[c]):
             try:
                 if int(row[c]) == 1:
                     return "broken"
@@ -16,7 +16,7 @@ def mark_type_from_division_row(row: pd.Series) -> str:
                 pass
 
     for c in row.index:
-        if "種別" in c and pd.notna(row[c]):
+        if "種別" in c and notna(row[c]):
             try:
                 v = int(row[c])
                 return "solid" if v in (1, 2) else "broken"

--- a/csv2xodr/mini_yaml.py
+++ b/csv2xodr/mini_yaml.py
@@ -1,0 +1,100 @@
+"""A tiny YAML loader supporting the subset used by csv2xodr configs."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Sequence, Tuple
+
+
+def _strip_comments(line: str) -> str:
+    if "#" in line:
+        idx = line.index("#")
+        return line[:idx]
+    return line
+
+
+def _parse_scalar(value: str) -> Any:
+    lower = value.lower()
+    if lower == "true":
+        return True
+    if lower == "false":
+        return False
+    try:
+        if value.startswith("0") and value != "0" and not value.startswith("0."):
+            raise ValueError
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return value
+
+
+def _preprocess(lines: Iterable[str]) -> List[Tuple[int, str]]:
+    processed: List[Tuple[int, str]] = []
+    for raw in lines:
+        stripped = _strip_comments(raw).rstrip()
+        if not stripped:
+            continue
+        indent = len(stripped) - len(stripped.lstrip())
+        content = stripped.lstrip()
+        processed.append((indent, content))
+    return processed
+
+
+def _parse_block(lines: Sequence[Tuple[int, str]], index: int, indent: int):
+    if index >= len(lines):
+        return {}, index
+    current_indent, text = lines[index]
+    if current_indent < indent:
+        return {}, index
+    if text.startswith("- "):
+        result: List[Any] = []
+        while index < len(lines):
+            level, line = lines[index]
+            if level != indent or not line.startswith("- "):
+                break
+            item_text = line[2:].strip()
+            index += 1
+            if index < len(lines) and lines[index][0] > indent:
+                child, index = _parse_block(lines, index, indent + 2)
+                if item_text:
+                    result.append(_parse_scalar(item_text))
+                result.append(child)
+            else:
+                result.append(_parse_scalar(item_text))
+        return result, index
+
+    result_dict: dict = {}
+    while index < len(lines):
+        level, line = lines[index]
+        if level < indent:
+            break
+        if level > indent:
+            raise ValueError(f"Unexpected indentation at line: {line}")
+        if ":" not in line:
+            raise ValueError(f"Invalid line (expected key: value): {line}")
+        key, value_text = line.split(":", 1)
+        key = key.strip()
+        value_text = value_text.strip()
+        index += 1
+        if value_text == "":
+            if index < len(lines) and lines[index][0] > indent:
+                child, index = _parse_block(lines, index, indent + 2)
+                result_dict[key] = child
+            else:
+                result_dict[key] = {}
+        else:
+            result_dict[key] = _parse_scalar(value_text)
+    return result_dict, index
+
+
+def load(path: str) -> Any:
+    with open(path, encoding="utf-8") as fh:
+        lines = _preprocess(fh)
+    if not lines:
+        return {}
+    data, _ = _parse_block(lines, 0, lines[0][0])
+    return data
+

--- a/csv2xodr/normalize/core.py
+++ b/csv2xodr/normalize/core.py
@@ -1,26 +1,30 @@
 import math
-import numpy as np
-import pandas as pd
+from typing import Iterable, List, Tuple
 
-def _col_like(df: pd.DataFrame, keyword: str):
+from csv2xodr.simpletable import DataFrame
+
+def _col_like(df: DataFrame, keyword: str):
     cols = [c for c in df.columns if keyword in c]
     return cols[0] if cols else None
 
-def latlon_to_local_xy(lat, lon, lat0, lon0):
+def latlon_to_local_xy(lat: Iterable[float], lon: Iterable[float], lat0: float, lon0: float) -> Tuple[List[float], List[float]]:
     """
     Simple equirectangular projection to local XY [m].
     lat/lon can be numpy arrays in degrees.
     """
     R = 6378137.0
-    lat = np.deg2rad(lat)
-    lon = np.deg2rad(lon)
-    lat0 = math.radians(lat0)
-    lon0 = math.radians(lon0)
-    x = (lon - lon0) * np.cos((lat + lat0) / 2.0) * R
-    y = (lat - lat0) * R
-    return x, y
+    lat_rad = [math.radians(v) for v in lat]
+    lon_rad = [math.radians(v) for v in lon]
+    lat0_rad = math.radians(lat0)
+    lon0_rad = math.radians(lon0)
+    x_vals = [
+        (lon_v - lon0_rad) * math.cos((lat_v + lat0_rad) / 2.0) * R
+        for lat_v, lon_v in zip(lat_rad, lon_rad)
+    ]
+    y_vals = [(lat_v - lat0_rad) * R for lat_v in lat_rad]
+    return x_vals, y_vals
 
-def build_centerline(df_line_geo: pd.DataFrame, df_base: pd.DataFrame):
+def build_centerline(df_line_geo: DataFrame, df_base: DataFrame):
     """
     Build centerline planView from PROFILETYPE_MPU_LINE_GEOMETRY (lat/lon series).
     Returns: centerline DataFrame [s,x,y,hdg], and (lat0, lon0)
@@ -42,16 +46,15 @@ def build_centerline(df_line_geo: pd.DataFrame, df_base: pd.DataFrame):
     # single centerline instead of weaving across multiple boundaries (which
     # renders as a cross/diamond artifact in the exported OpenDRIVE).
     if offsets_series is not None and offsets_series.duplicated().any():
-        grouped = (
-            df_line_geo.groupby(offset_col, sort=True)[[lat_col, lon_col]].mean().reset_index()
-        )
-        lat = grouped[lat_col].to_numpy()
-        lon = grouped[lon_col].to_numpy()
-        offsets = grouped[offset_col].to_numpy()
+        grouped = df_line_geo.groupby(offset_col, sort=True)[[lat_col, lon_col]].mean().reset_index()
+        df_line_geo = grouped
+        lat = [float(v) for v in grouped[lat_col].to_list()]
+        lon = [float(v) for v in grouped[lon_col].to_list()]
+        offsets = [float(v) for v in grouped[offset_col].to_list()]
     else:
-        lat = df_line_geo[lat_col].astype(float).to_numpy()
-        lon = df_line_geo[lon_col].astype(float).to_numpy()
-        offsets = offsets_series.to_numpy() if offsets_series is not None else None
+        lat = [float(v) for v in df_line_geo[lat_col].astype(float).to_list()]
+        lon = [float(v) for v in df_line_geo[lon_col].astype(float).to_list()]
+        offsets = offsets_series.to_list() if offsets_series is not None else None
 
     # Some datasets interleave multiple Path Id polylines. Stick to the longest one to
     # avoid creating self-crossing planViews.
@@ -63,35 +66,40 @@ def build_centerline(df_line_geo: pd.DataFrame, df_base: pd.DataFrame):
         lengths = {}
         path_series = df_line_geo[path_col]
         for pid in path_series.dropna().unique():
-            mask = (path_series == pid).to_numpy()
-            idx = np.flatnonzero(mask)
-            if len(idx) < 2:
+            indices = [i for i, value in enumerate(path_series.to_list()) if value == pid]
+            if len(indices) < 2:
                 continue
-            ds = np.hypot(np.diff(x_tmp[idx]), np.diff(y_tmp[idx]))
-            if len(ds):
-                lengths[pid] = float(ds.sum())
+            ds_total = 0.0
+            for i in range(len(indices) - 1):
+                a = indices[i]
+                b = indices[i + 1]
+                dx = x_tmp[b] - x_tmp[a]
+                dy = y_tmp[b] - y_tmp[a]
+                ds_total += math.hypot(dx, dy)
+            if ds_total > 0:
+                lengths[pid] = ds_total
         if lengths:
             best_pid = max(lengths, key=lengths.get)
         else:
             best_pid = path_series.dropna().iloc[0]
-        keep_mask = (path_series == best_pid).to_numpy()
+        keep_mask = [value == best_pid for value in path_series.to_list()]
         df_line_geo = df_line_geo.loc[keep_mask].reset_index(drop=True)
-        lat = lat[keep_mask]
-        lon = lon[keep_mask]
+        lat = [value for value, keep in zip(lat, keep_mask) if keep]
+        lon = [value for value, keep in zip(lon, keep_mask) if keep]
 
     # choose origin
     if df_base is not None and len(df_base) > 0:
         lat0 = float(df_base.filter(like="緯度").iloc[0, 0])
         lon0 = float(df_base.filter(like="経度").iloc[0, 0])
     else:
-        lat0 = float(np.mean(lat))
-        lon0 = float(np.mean(lon))
+        lat0 = sum(lat) / len(lat)
+        lon0 = sum(lon) / len(lon)
 
     x, y = latlon_to_local_xy(lat, lon, lat0, lon0)
 
     # cumulative s & heading
-    s = np.zeros_like(x)
-    hdg = np.zeros_like(x)
+    s = [0.0 for _ in x]
+    hdg = [0.0 for _ in x]
     for i in range(1, len(x)):
         dx, dy = (x[i] - x[i - 1]), (y[i] - y[i - 1])
         ds = math.hypot(dx, dy)
@@ -101,14 +109,15 @@ def build_centerline(df_line_geo: pd.DataFrame, df_base: pd.DataFrame):
         hdg[-1] = hdg[-2]
 
     if offsets is not None and len(offsets) == len(s):
-        offsets = np.asarray(offsets, dtype=float)
-        if len(offsets):
-            offsets = offsets - offsets[0]
-            if s[-1] > 0 and offsets[-1] > 0:
-                ratio = offsets[-1] / s[-1]
+        offsets_f = [float(v) for v in offsets]
+        if offsets_f:
+            start = offsets_f[0]
+            offsets_norm = [v - start for v in offsets_f]
+            if s[-1] > 0 and offsets_norm[-1] > 0:
+                ratio = offsets_norm[-1] / s[-1]
                 if ratio > 10.0:
-                    offsets = offsets * 0.01
-            s = offsets
+                    offsets_norm = [v * 0.01 for v in offsets_norm]
+            s = offsets_norm
 
-    center = pd.DataFrame({"s": s, "x": x, "y": y, "hdg": hdg})
+    center = DataFrame({"s": s, "x": x, "y": y, "hdg": hdg})
     return center, (lat0, lon0)

--- a/csv2xodr/simpletable.py
+++ b/csv2xodr/simpletable.py
@@ -1,0 +1,388 @@
+"""A very small subset of pandas-like functionality used by csv2xodr.
+
+This module implements light-weight :class:`DataFrame` and :class:`Series`
+objects that support the handful of operations required by the converter.
+It intentionally does **not** try to be a drop-in replacement for pandas –
+only the methods/behaviours that are exercised inside this project are
+implemented.  The goal is to keep the tool functional in minimal
+environments where installing heavy third-party dependencies such as
+``pandas`` or ``numpy`` is not feasible.
+
+The implementation focuses on:
+
+* column selection via ``df["col"]`` and ``df[["a", "b"]]``
+* ``len(df)`` and ``len(series)``
+* integer based indexing via ``iloc`` for both series and data frames
+* boolean/sequence indexing via ``loc``
+* ``filter(like="...")``
+* a very small ``groupby`` with ``mean`` aggregation
+* helpers such as ``dropna()``, ``unique()``, ``duplicated()`` and
+  ``astype(float)`` on series
+
+Only the behaviour that is explicitly relied upon by the rest of the
+code base is implemented here.  The API is intentionally tiny but it is
+documented and unit tested through the higher-level features of the
+converter.  When new functionality is required it can be extended in a
+controlled manner.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Union
+
+
+def _is_na(value: Any) -> bool:
+    """Return ``True`` when *value* should be treated as missing/NaN."""
+
+    if value is None:
+        return True
+    if isinstance(value, float) and math.isnan(value):
+        return True
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped == "" or stripped.lower() == "nan":
+            return True
+    return False
+
+
+def notna(value: Any) -> bool:
+    """Inverse of :func:`_is_na` to mimic ``pandas.notna``."""
+
+    return not _is_na(value)
+
+
+class Series:
+    """A light-weight sequence with a pandas-like interface."""
+
+    def __init__(
+        self,
+        data: Iterable[Any],
+        *,
+        index: Optional[Sequence[Any]] = None,
+        name: Optional[str] = None,
+        kind: str = "column",
+    ) -> None:
+        self._data: List[Any] = list(data)
+        self.name = name
+        self._kind = kind
+        if index is None:
+            if kind == "column":
+                self.index: List[Any] = list(range(len(self._data)))
+            else:
+                self.index = [None for _ in self._data]
+        else:
+            self.index = list(index)
+
+    # ------------------------------------------------------------------
+    # Representation helpers
+    def __len__(self) -> int:  # pragma: no cover - behaviour validated indirectly
+        return len(self._data)
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._data)
+
+    def __getitem__(self, key: Union[int, str]) -> Any:
+        if self._kind == "row" and isinstance(key, str):
+            try:
+                idx = self.index.index(key)
+            except ValueError as exc:  # pragma: no cover - defensive programming
+                raise KeyError(key) from exc
+            return self._data[idx]
+        return self._data[key]
+
+    @property
+    def values(self) -> List[Any]:
+        return list(self._data)
+
+    def to_list(self) -> List[Any]:
+        return list(self._data)
+
+    def to_numpy(self) -> List[Any]:  # compatibility shim
+        return list(self._data)
+
+    def astype(self, dtype) -> "Series":
+        converted: List[Any] = []
+        for value in self._data:
+            if _is_na(value):
+                if dtype is float:
+                    converted.append(math.nan)
+                else:
+                    converted.append(dtype())
+                continue
+            converted.append(dtype(value))
+        return Series(converted, index=self.index, name=self.name, kind=self._kind)
+
+    def duplicated(self) -> "Series":
+        seen: set = set()
+        flags: List[bool] = []
+        for value in self._data:
+            if _is_na(value):
+                flags.append(False)
+                continue
+            if value in seen:
+                flags.append(True)
+            else:
+                seen.add(value)
+                flags.append(False)
+        return Series(flags, index=self.index, kind=self._kind)
+
+    def any(self) -> bool:
+        return any(bool(v) for v in self._data)
+
+    def dropna(self) -> "Series":
+        data: List[Any] = []
+        new_index: List[Any] = []
+        for idx, value in zip(self.index, self._data):
+            if _is_na(value):
+                continue
+            data.append(value)
+            new_index.append(idx)
+        return Series(data, index=new_index, name=self.name, kind=self._kind)
+
+    def unique(self) -> List[Any]:
+        seen: List[Any] = []
+        for value in self._data:
+            if _is_na(value):
+                continue
+            if value not in seen:
+                seen.append(value)
+        return seen
+
+    def nunique(self, dropna: bool = True) -> int:
+        if dropna:
+            return len(self.dropna().unique())
+        return len(Series(self._data, index=self.index).unique())
+
+    def iloc(self, idx: int) -> Any:  # pragma: no cover - retained for backward compat
+        return self._data[idx]
+
+    # pandas-like attribute
+    @property
+    def iloc(self) -> "_SeriesILoc":  # type: ignore[override]
+        return _SeriesILoc(self)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"Series({self._data})"
+
+
+class _SeriesILoc:
+    def __init__(self, series: Series) -> None:
+        self._series = series
+
+    def __getitem__(self, item: Union[int, slice]) -> Union[Any, Series]:
+        if isinstance(item, slice):
+            return Series(
+                self._series._data[item],
+                index=self._series.index[item],
+                name=self._series.name,
+                kind=self._series._kind,
+            )
+        return self._series._data[item]
+
+
+class DataFrame:
+    """A tabular structure that mimics a very small portion of pandas."""
+
+    def __init__(self, data: Union[Dict[str, Iterable[Any]], Iterable[Dict[str, Any]]], *, columns: Optional[List[str]] = None) -> None:
+        if isinstance(data, dict):
+            cols = list(data.keys())
+            length = 0
+            for col in cols:
+                values = list(data[col])
+                data[col] = values
+                length = len(values)
+            rows: List[Dict[str, Any]] = []
+            for i in range(length):
+                row = {col: data[col][i] for col in cols}
+                rows.append(row)
+            self._rows = rows
+            self.columns = cols
+        else:
+            rows = [dict(row) for row in data]
+            self._rows = rows
+            if columns is not None:
+                self.columns = list(columns)
+            elif rows:
+                self.columns = list(rows[0].keys())
+            else:
+                self.columns = []
+
+    # ------------------------------------------------------------------
+    def __len__(self) -> int:
+        return len(self._rows)
+
+    def __getitem__(self, item: Union[str, List[str]]) -> Union[Series, "DataFrame"]:
+        if isinstance(item, str):
+            return Series([row.get(item) for row in self._rows], name=item, kind="column")
+        elif isinstance(item, list):
+            subset = [{col: row.get(col) for col in item} for row in self._rows]
+            return DataFrame(subset, columns=item)
+        else:  # pragma: no cover - defensive programming
+            raise TypeError("Unsupported key type")
+
+    # pandas-like indexers -------------------------------------------------
+    @property
+    def iloc(self) -> "_DataFrameILoc":
+        return _DataFrameILoc(self)
+
+    @property
+    def loc(self) -> "_DataFrameLoc":
+        return _DataFrameLoc(self)
+
+    # ------------------------------------------------------------------
+    def filter(self, like: Optional[str] = None) -> "DataFrame":
+        if like is None:
+            return DataFrame(self._rows, columns=self.columns)
+        cols = [c for c in self.columns if like in c]
+        return self[cols]
+
+    def groupby(self, column: str, sort: bool = True) -> "_GroupBy":
+        return _GroupBy(self, column, sort=sort)
+
+    def reset_index(self, drop: bool = False) -> "DataFrame":
+        if drop:
+            return DataFrame(self._rows, columns=self.columns)
+        new_rows: List[Dict[str, Any]] = []
+        for idx, row in enumerate(self._rows):
+            new_row = dict(row)
+            new_row["index"] = idx
+            new_rows.append(new_row)
+        cols = ["index"] + [c for c in self.columns if c != "index"]
+        return DataFrame(new_rows, columns=cols)
+
+    def to_dicts(self) -> List[Dict[str, Any]]:  # pragma: no cover - debug helper
+        return [dict(row) for row in self._rows]
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"DataFrame(rows={len(self)}, columns={self.columns})"
+
+
+class _DataFrameILoc:
+    def __init__(self, df: DataFrame) -> None:
+        self._df = df
+
+    def _resolve_row(self, selector: Union[int, slice, List[int]]) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        rows = self._df._rows
+        if isinstance(selector, int):
+            return rows[selector]
+        if isinstance(selector, slice):
+            return rows[selector]
+        if isinstance(selector, list):
+            return [rows[i] for i in selector]
+        raise TypeError("Unsupported iloc row selector")
+
+    def _resolve_columns(self, selector: Union[int, slice, List[int]]) -> List[str]:
+        cols = self._df.columns
+        if isinstance(selector, int):
+            return [cols[selector]]
+        if isinstance(selector, slice):
+            return cols[selector]
+        if isinstance(selector, list):
+            return [cols[i] for i in selector]
+        raise TypeError("Unsupported iloc column selector")
+
+    def __getitem__(self, item: Union[int, slice, Tuple[Union[int, slice, List[int]], Union[int, slice, List[int]]]]):
+        if isinstance(item, tuple):
+            row_sel, col_sel = item
+            rows = self._resolve_row(row_sel)
+            cols = self._resolve_columns(col_sel)
+            if isinstance(rows, list):
+                subset = [{col: row.get(col) for col in cols} for row in rows]
+                if len(subset) == 1 and len(cols) == 1:
+                    return subset[0][cols[0]]
+                return DataFrame(subset, columns=cols)
+            else:
+                row = rows
+                if len(cols) == 1:
+                    return row.get(cols[0])
+                return Series([row.get(col) for col in cols], index=cols, kind="row")
+
+        rows = self._resolve_row(item)
+        if isinstance(rows, list):
+            return DataFrame(rows, columns=self._df.columns)
+        return Series([rows.get(col) for col in self._df.columns], index=self._df.columns, kind="row")
+
+
+class _DataFrameLoc:
+    def __init__(self, df: DataFrame) -> None:
+        self._df = df
+
+    def __getitem__(self, item: Union[slice, List[bool], List[int]]):
+        rows = self._df._rows
+        if isinstance(item, slice):
+            return DataFrame(rows[item], columns=self._df.columns)
+        if isinstance(item, list):
+            if all(isinstance(v, bool) for v in item):
+                selected = [row for row, keep in zip(rows, item) if keep]
+                return DataFrame(selected, columns=self._df.columns)
+            if all(isinstance(v, int) for v in item):
+                selected = [rows[i] for i in item]
+                return DataFrame(selected, columns=self._df.columns)
+        raise TypeError("Unsupported loc selector")
+
+
+class _GroupBy:
+    def __init__(self, df: DataFrame, column: str, *, sort: bool = True) -> None:
+        self._df = df
+        self._column = column
+        self._sort = sort
+
+    def __getitem__(self, columns: List[str]) -> "_GroupBySelection":
+        return _GroupBySelection(self._df, self._column, columns, self._sort)
+
+
+class _GroupBySelection:
+    def __init__(self, df: DataFrame, group_col: str, columns: List[str], sort: bool) -> None:
+        self._df = df
+        self._group_col = group_col
+        self._columns = columns
+        self._sort = sort
+
+    def mean(self) -> DataFrame:
+        sums: Dict[Any, Dict[str, float]] = {}
+        counts: Dict[Any, Dict[str, int]] = {}
+        for row in self._df._rows:
+            key = row.get(self._group_col)
+            if _is_na(key):
+                continue
+            if key not in sums:
+                sums[key] = {col: 0.0 for col in self._columns}
+                counts[key] = {col: 0 for col in self._columns}
+            for col in self._columns:
+                value = row.get(col)
+                if _is_na(value):
+                    continue
+                try:
+                    fval = float(value)
+                except Exception:  # pragma: no cover - mirrors pandas behaviour
+                    continue
+                sums[key][col] += fval
+                counts[key][col] += 1
+
+        keys = list(sums.keys())
+        if self._sort:
+            try:
+                keys.sort()
+            except TypeError:  # pragma: no cover - fall back to insertion order
+                pass
+
+        out_rows: List[Dict[str, Any]] = []
+        for key in keys:
+            row: Dict[str, Any] = {self._group_col: key}
+            for col in self._columns:
+                count = counts[key][col]
+                if count == 0:
+                    row[col] = None
+                else:
+                    row[col] = sums[key][col] / count
+            out_rows.append(row)
+        return DataFrame(out_rows, columns=[self._group_col] + self._columns)
+
+
+__all__ = [
+    "DataFrame",
+    "Series",
+    "notna",
+]
+


### PR DESCRIPTION
## Summary
- 引入轻量级 simpletable 模块替代 pandas DataFrame/Series 功能，支持 iloc/loc、groupby 等核心操作
- 新增 mini_yaml 解析器，当环境缺少 PyYAML 时也能加载配置
- 调整 csv2xodr 相关流程以使用自定义表结构，并使用纯 Python 数值算法生成中心线

## Testing
- python csv2xodr/csv2xodr.py --input ./input_csv --output ./out/sample.xodr --config ./csv2xodr/config.yaml
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cbaf6d3d64832783a215371040d8d7