### PR TITLE
Use lane CSVs for lane links and road marks

### DIFF
--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -41,7 +41,7 @@ def main():
     sections = make_sections(center, dfs["lane_link"], dfs["lane_division"])
 
     # lane topology hints (no center id in the guess)
-    lane_topo, uniq_lane_ids = build_lane_topology(dfs["lane_link"])
+    lane_topo = build_lane_topology(dfs["lane_link"])
 
     # per-section spec (width/roadMark/topology flags)
     lane_specs = build_lane_spec(sections, lane_topo, cfg.get("defaults", {}), dfs["lane_division"])
@@ -68,8 +68,9 @@ def main():
         "output_counts": {
             "roads": 1,
             "laneSections": len(lane_specs),
-            # +1 center per section; lanes list excludes center(0)
-            "lanes_total": sum(len(sec["lanes"]) + 1 for sec in lane_specs)
+            "lanes_total": sum(
+                1 + len(sec.get("left", [])) + len(sec.get("right", [])) for sec in lane_specs
+            ),
         },
         "road_length_m": float(center["s"].iloc[-1]) if len(center["s"]) else 0.0,
         "xodr_file": {

--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -1,6 +1,115 @@
 """Helpers for building per-section lane specifications."""
 
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from csv2xodr.mapping.core import mark_type_from_division_row
+from csv2xodr.simpletable import DataFrame
+
+
+def _lookup_line_segment(segments: List[Dict[str, Any]], s0: float, s1: float) -> Optional[Dict[str, Any]]:
+    for seg in segments:
+        if seg["s1"] <= s0:
+            continue
+        if seg["s0"] >= s1:
+            continue
+        return seg
+    return segments[0] if segments else None
+
+
+def _build_division_lookup(lane_div_df: Optional[DataFrame]) -> Dict[str, List[Dict[str, Any]]]:
+    if lane_div_df is None or len(lane_div_df) == 0:
+        return {}
+
+    cols = list(lane_div_df.columns)
+
+    def find_col(*keywords: str) -> Optional[str]:
+        for col in cols:
+            stripped = col.strip()
+            if all(keyword in stripped for keyword in keywords):
+                return col
+        return None
+
+    start_col = find_col("Offset")
+    end_col = find_col("End", "Offset")
+    line_id_col = find_col("区画線ID") or find_col("ライン", "ID") or find_col("対象の区画線ID")
+    start_w_col = find_col("始点側線幅")
+    end_w_col = find_col("終点側線幅")
+    is_retrans_col = find_col("Is", "Retransmission")
+
+    if line_id_col is None or start_col is None or end_col is None:
+        return {}
+
+    records: Dict[Tuple[str, float, float], Dict[str, Any]] = {}
+    for i in range(len(lane_div_df)):
+        row = lane_div_df.iloc[i]
+        try:
+            start = float(row[start_col]) / 100.0
+            end = float(row[end_col]) / 100.0
+        except Exception:
+            continue
+        if end <= start:
+            continue
+
+        line_id_raw = row[line_id_col]
+        line_id = str(line_id_raw).strip()
+        if line_id in {"", "0", "0.0", "-1", "-1.0"}:
+            continue
+
+        width_values: List[float] = []
+        for col in (start_w_col, end_w_col):
+            if not col:
+                continue
+            try:
+                val = float(row[col]) / 100.0
+                if val > 0:
+                    width_values.append(val)
+            except Exception:
+                continue
+        width = sum(width_values) / len(width_values) if width_values else None
+
+        is_retrans = False
+        if is_retrans_col:
+            is_retrans = str(row[is_retrans_col]).strip().lower() == "true"
+
+        key = (line_id, start, end)
+        existing = records.get(key)
+        if existing is not None:
+            if existing["is_retrans"] and not is_retrans:
+                records[key] = {"row": row, "width": width, "is_retrans": is_retrans}
+            continue
+
+        records[key] = {"row": row, "width": width, "is_retrans": is_retrans}
+
+    grouped: Dict[str, List[Tuple[float, float, Dict[str, Any]]]] = {}
+    for (line_id, start, end), data in records.items():
+        grouped.setdefault(line_id, []).append((start, end, data))
+
+    lookup: Dict[str, List[Dict[str, Any]]] = {}
+    for line_id, segments in grouped.items():
+        segments.sort(key=lambda item: (item[0], item[1]))
+        cleaned: List[Dict[str, Any]] = []
+        for start, end, data in segments:
+            if cleaned:
+                prev = cleaned[-1]
+                if abs(prev["s0"] - start) < 1e-6 and abs(prev["s1"] - end) < 1e-6:
+                    continue
+                if start < prev["s1"]:
+                    start = max(prev["s1"], start)
+                    if start >= end:
+                        continue
+
+            mark_type = mark_type_from_division_row(data["row"])
+            cleaned.append({
+                "s0": start,
+                "s1": end,
+                "type": mark_type,
+                "width": data["width"],
+            })
+
+        if cleaned:
+            lookup[line_id] = cleaned
+
+    return lookup
 
 
 def build_lane_spec(
@@ -11,31 +120,195 @@ def build_lane_spec(
 ) -> List[Dict[str, Any]]:
     """Return metadata for each lane section used by the writer."""
 
-    lanes_guess = (lane_topo or {}).get("lanes_guess") or [1, -1]
-
-
-    roadmark_type = "solid"
-    if lane_div_df is not None and len(lane_div_df) > 0:
-        from csv2xodr.mapping.core import mark_type_from_division_row
-
-        roadmark_type = mark_type_from_division_row(lane_div_df.iloc[0])
-
     sections_list = list(sections)
-    total = len(sections_list)
+    lane_info = (lane_topo or {}).get("lanes") or {}
+    lane_groups = (lane_topo or {}).get("groups") or {}
+    lane_count = (lane_topo or {}).get("lane_count") or 0
+
+    if not lane_info:
+        # fallback to the previous heuristic
+        lanes_guess = [1, -1]
+        total = len(sections_list)
+        out: List[Dict[str, Any]] = []
+        roadmark_type = "solid"
+        if lane_div_df is not None and len(lane_div_df) > 0:
+            roadmark_type = mark_type_from_division_row(lane_div_df.iloc[0])
+        for idx, sec in enumerate(sections_list):
+            out.append(
+                {
+                    "s0": sec["s0"],
+                    "s1": sec["s1"],
+                    "left": [
+                        {
+                            "id": 1,
+                            "width": defaults.get("lane_width_m", 3.5),
+                            "roadMark": {
+                                "type": roadmark_type,
+                                "width": 0.12,
+                                "laneChange": "both" if roadmark_type != "solid" else "none",
+                            },
+                            "successors": [1] if idx < total - 1 else [],
+                            "predecessors": [1] if idx > 0 else [],
+                        }
+                    ],
+                    "right": [
+                        {
+                            "id": -1,
+                            "width": defaults.get("lane_width_m", 3.5),
+                            "roadMark": {
+                                "type": roadmark_type,
+                                "width": 0.12,
+                                "laneChange": "both" if roadmark_type != "solid" else "none",
+                            },
+                            "successors": [-1] if idx < total - 1 else [],
+                            "predecessors": [-1] if idx > 0 else [],
+                        }
+                    ],
+                }
+            )
+        return out
+
+    division_lookup = _build_division_lookup(lane_div_df)
+
+    base_ids = sorted(lane_groups.keys())
+    lanes_per_base = {base: len(lane_groups[base]) for base in base_ids}
+
+    target_left = lane_count // 2 if lane_count else sum(lanes_per_base.values()) // 2
+    left_bases: List[str] = []
+    acc = 0
+    for base in base_ids:
+        if acc < target_left:
+            left_bases.append(base)
+            acc += lanes_per_base[base]
+    right_bases = [base for base in base_ids if base not in left_bases]
+    if not left_bases and base_ids:
+        left_bases = base_ids[:1]
+        right_bases = [base for base in base_ids if base not in left_bases]
+
+    lane_id_map: Dict[str, int] = {}
+    lane_side_map: Dict[str, str] = {}
+
+    current_id = 1
+    for base in left_bases:
+        for uid in reversed(sorted(lane_groups.get(base, []), key=lambda x: lane_info[x]["lane_no"])):
+            lane_id_map[uid] = current_id
+            lane_side_map[uid] = "left"
+            current_id += 1
+
+    current_id = -1
+    for base in right_bases:
+        for uid in reversed(sorted(lane_groups.get(base, []), key=lambda x: lane_info[x]["lane_no"])):
+            lane_id_map[uid] = current_id
+            lane_side_map[uid] = "right"
+            current_id -= 1
+
+    lane_section_map: Dict[Tuple[str, int], Dict[str, Any]] = {}
+    lane_section_indices: Dict[str, List[int]] = {uid: [] for uid in lane_id_map}
+    for idx, sec in enumerate(sections_list):
+        s0 = sec["s0"]
+        s1 = sec["s1"]
+        for uid, info in lane_info.items():
+            if uid not in lane_id_map:
+                continue
+            segment = None
+            for seg in info["segments"]:
+                if seg["end"] <= s0 or seg["start"] >= s1:
+                    continue
+                segment = seg
+                break
+            if segment is None:
+                continue
+            lane_section_map[(uid, idx)] = segment
+            lane_section_indices[uid].append(idx)
+
+    lane_section_pos: Dict[Tuple[str, int], int] = {}
+    for uid, indices in lane_section_indices.items():
+        for order, sec_idx in enumerate(indices):
+            lane_section_pos[(uid, sec_idx)] = order
 
     out: List[Dict[str, Any]] = []
     for idx, sec in enumerate(sections_list):
-        has_prev = idx > 0
-        has_next = idx < total - 1
-        out.append(
-            {
-                "s0": sec["s0"],
-                "s1": sec["s1"],
-                "lanes": lanes_guess,
-                "lane_width": defaults.get("lane_width_m", 3.5),
-                "roadMark": roadmark_type,
-                "predecessor": has_prev,
-                "successor": has_next,
+        section_left: List[Dict[str, Any]] = []
+        section_right: List[Dict[str, Any]] = []
+        s0 = sec["s0"]
+        s1 = sec["s1"]
+
+        for uid, lane_id in lane_id_map.items():
+            segment = lane_section_map.get((uid, idx))
+            if segment is None:
+                continue
+
+            side = lane_side_map[uid]
+            lane_no = lane_info[uid]["lane_no"]
+            width = segment.get("width") or defaults.get("lane_width_m", 3.5)
+
+            if isinstance(width, str):
+                try:
+                    width = float(width)
+                except Exception:
+                    width = defaults.get("lane_width_m", 3.5)
+
+            lane_indices = lane_section_indices[uid]
+            order = lane_section_pos[(uid, idx)]
+
+            predecessors: List[int] = []
+            if order > 0:
+                predecessors.append(lane_id)
+            else:
+                for target in segment.get("predecessors", []):
+                    mapped = lane_id_map.get(target)
+                    if mapped is not None:
+                        predecessors.append(mapped)
+
+            successors: List[int] = []
+            if order < len(lane_indices) - 1:
+                successors.append(lane_id)
+            else:
+                for target in segment.get("successors", []):
+                    mapped = lane_id_map.get(target)
+                    if mapped is not None:
+                        successors.append(mapped)
+
+            pos_key = 2 if side == "left" else 1
+            alt_key = 1 if side == "left" else 2
+            line_id = segment.get("line_positions", {}).get(pos_key)
+            if not line_id:
+                line_id = segment.get("line_positions", {}).get(alt_key)
+
+            mark = None
+            if line_id:
+                mark_segment = _lookup_line_segment(division_lookup.get(line_id, []), s0, s1)
+                if mark_segment:
+                    mark_width = mark_segment.get("width") or 0.12
+                    lane_change = "both" if mark_segment.get("type") != "solid" else "none"
+                    mark = {
+                        "type": mark_segment.get("type") or "solid",
+                        "width": mark_width,
+                        "laneChange": lane_change,
+                    }
+
+            if mark is None:
+                lane_change = "both"
+                mark = {"type": "solid", "width": 0.12, "laneChange": lane_change}
+
+            lane_entry = {
+                "uid": uid,
+                "id": lane_id,
+                "lane_no": lane_no,
+                "width": width,
+                "roadMark": mark,
+                "predecessors": predecessors,
+                "successors": successors,
             }
-        )
+
+            if side == "left":
+                section_left.append(lane_entry)
+            else:
+                section_right.append(lane_entry)
+
+        section_left.sort(key=lambda item: item["id"])
+        section_right.sort(key=lambda item: item["id"], reverse=True)
+
+        out.append({"s0": s0, "s1": s1, "left": section_left, "right": section_right})
+
     return out


### PR DESCRIPTION
## Summary
- normalize lane_link rows into canonical lane segments, resolving duplicates and successor/predecessor ids
- build per-section lane specs with lane_div derived road-mark metadata and real lane ids
- update the writer/cli to emit the new lane structure and derived statistics

## Testing
- pytest
- python csv2xodr/csv2xodr.py --input input_csv --output out/generated.xodr --config csv2xodr/config.yaml


------
https://chatgpt.com/codex/tasks/task_e_68cbb3ea35a48327918d4c7a5b12e0ef