### PR TITLE
Add explicit line geometry parsing and integrate with lane spec

### DIFF
--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -11,6 +11,7 @@ if __package__ is None or __package__ == "":
 
 from csv2xodr.ingest.loader import load_all
 from csv2xodr.normalize.core import build_centerline, build_offset_mapper
+from csv2xodr.line_geometry import build_line_geometry_lookup
 from csv2xodr.topology.core import make_sections, build_lane_topology
 from csv2xodr.writer.xodr_writer import write_xodr
 from csv2xodr.lane_spec import build_lane_spec
@@ -45,11 +46,15 @@ def main():
     lane_topo = build_lane_topology(dfs["lane_link"], offset_mapper=offset_mapper)
 
     # per-section spec (width/roadMark/topology flags)
+    line_geometry_lookup = build_line_geometry_lookup(
+        dfs["line_geometry"], offset_mapper=offset_mapper, lat0=lat0, lon0=lon0
+    )
     lane_specs = build_lane_spec(
         sections,
         lane_topo,
         cfg.get("defaults", {}),
         dfs["lane_division"],
+        line_geometry_lookup=line_geometry_lookup,
         offset_mapper=offset_mapper,
     )
 

--- a/csv2xodr/line_geometry.py
+++ b/csv2xodr/line_geometry.py
@@ -1,0 +1,181 @@
+"""Utilities for parsing white line geometry from CSV inputs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from csv2xodr.normalize.core import latlon_to_local_xy
+from csv2xodr.simpletable import DataFrame
+from csv2xodr.topology.core import _canonical_numeric
+
+
+def _find_column(columns: Iterable[str], *keywords: str) -> Optional[str]:
+    lowered = [kw.lower() for kw in keywords]
+    for col in columns:
+        stripped = col.strip()
+        value = stripped.lower()
+        if all(keyword in value for keyword in lowered):
+            return col
+    return None
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if text == "" or text.lower() == "nan":
+            return None
+        return float(text)
+    except Exception:  # pragma: no cover - defensive
+        return None
+
+
+def _geometry_signature(points: List[Tuple[float, float, float, float]]) -> Tuple[Tuple[int, int, int, int], ...]:
+    return tuple(
+        (
+            int(round(s * 1000)),
+            int(round(x * 1000)),
+            int(round(y * 1000)),
+            int(round(z * 1000)),
+        )
+        for s, x, y, z in points
+    )
+
+
+def build_line_geometry_lookup(
+    line_geom_df: Optional[DataFrame],
+    *,
+    offset_mapper=None,
+    lat0: float,
+    lon0: float,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Return a lookup of canonical line IDs to polylines in local XY."""
+
+    if line_geom_df is None or len(line_geom_df) == 0:
+        return {}
+
+    cols = list(line_geom_df.columns)
+
+    line_id_col = _find_column(cols, "ライン", "ID") or _find_column(cols, "区画線", "ID")
+    lat_col = _find_column(cols, "緯度") or _find_column(cols, "Latitude")
+    lon_col = _find_column(cols, "経度") or _find_column(cols, "Longitude")
+    z_col = _find_column(cols, "高さ") or _find_column(cols, "標高") or _find_column(cols, "Height")
+    offset_col = None
+    for col in cols:
+        stripped = col.strip().lower()
+        if "offset" in stripped and "end" not in stripped:
+            offset_col = col
+            break
+    end_offset_col = _find_column(cols, "End", "Offset")
+    type_col = _find_column(cols, "Type") or _find_column(cols, "種別")
+    logtime_col = _find_column(cols, "ログ") or _find_column(cols, "log", "Time")
+    instance_col = _find_column(cols, "Instance") or _find_column(cols, "インスタンス")
+    flag_col = _find_column(cols, "3D") or _find_column(cols, "属性")
+    is_retrans_col = _find_column(cols, "Is", "Retransmission")
+
+    if line_id_col is None or lat_col is None or lon_col is None:
+        return {}
+
+    grouped: Dict[Tuple[str, Any, Any, Any, Any], Dict[str, Any]] = {}
+
+    offsets_raw: List[float] = []
+
+    for idx in range(len(line_geom_df)):
+        row = line_geom_df.iloc[idx]
+
+        line_id = _canonical_numeric(row[line_id_col], allow_negative=True)
+        if line_id is None:
+            continue
+
+        lat_val = _to_float(row[lat_col])
+        lon_val = _to_float(row[lon_col])
+        if lat_val is None or lon_val is None:
+            continue
+
+        z_val = _to_float(row[z_col]) if z_col else 0.0
+        if z_val is None:
+            z_val = 0.0
+
+        off_val = None
+        if offset_col is not None:
+            off_val = _to_float(row[offset_col])
+        if off_val is None and end_offset_col is not None:
+            off_val = _to_float(row[end_offset_col])
+
+        if off_val is None:
+            continue
+
+        offsets_raw.append(off_val)
+
+        group_key = (
+            line_id,
+            row[logtime_col] if logtime_col else None,
+            row[instance_col] if instance_col else None,
+            row[flag_col] if flag_col else None,
+            row[type_col] if type_col else None,
+        )
+
+        entry = grouped.setdefault(
+            group_key,
+            {
+                "line_id": line_id,
+                "lat": [],
+                "lon": [],
+                "z": [],
+                "offset": [],
+                "is_retrans": True,
+            },
+        )
+
+        retrans_flag = False
+        if is_retrans_col is not None:
+            retrans_flag = str(row[is_retrans_col]).strip().lower() == "true"
+        if not retrans_flag:
+            entry["is_retrans"] = False
+
+        entry["lat"].append(lat_val)
+        entry["lon"].append(lon_val)
+        entry["z"].append(z_val)
+        entry["offset"].append(off_val / 100.0)
+
+    if not grouped:
+        return {}
+
+    base_offset = min(offsets_raw) / 100.0 if offsets_raw else 0.0
+
+    lookup: Dict[str, List[Dict[str, Any]]] = {}
+
+    for entry in grouped.values():
+        if entry.get("is_retrans", False):
+            continue
+
+        offsets_m = [value - base_offset for value in entry["offset"]]
+        if offset_mapper is not None:
+            mapped_s = [offset_mapper(value) for value in offsets_m]
+        else:
+            mapped_s = offsets_m
+
+        x_vals, y_vals = latlon_to_local_xy(entry["lat"], entry["lon"], lat0, lon0)
+
+        points = list(zip(mapped_s, x_vals, y_vals, entry["z"]))
+        if not points:
+            continue
+
+        signature = _geometry_signature(points)
+
+        geoms = lookup.setdefault(entry["line_id"], [])
+        if any(_geometry_signature(list(zip(g["s"], g["x"], g["y"], g["z"]))) == signature for g in geoms):
+            continue
+
+        geoms.append(
+            {
+                "s": mapped_s,
+                "x": x_vals,
+                "y": y_vals,
+                "z": entry["z"],
+            }
+        )
+
+    return lookup
+

--- a/tests/test_lane_spec_geometry.py
+++ b/tests/test_lane_spec_geometry.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from csv2xodr.lane_spec import build_lane_spec
+from csv2xodr.simpletable import DataFrame
+
+
+def _make_lane_topology(line_id: str):
+    return {
+        "lane_count": 1,
+        "groups": {"A": ["A:1"]},
+        "lanes": {
+            "A:1": {
+                "lane_no": 1,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {2: line_id},
+                    }
+                ],
+            }
+        },
+    }
+
+
+def test_lane_spec_attaches_geometry_and_clips():
+    sections = [{"s0": 0.0, "s1": 4.0}, {"s0": 4.0, "s1": 10.0}]
+
+    lane_div = DataFrame(
+        [
+            {
+                "区画線ID": "100",
+                "Offset[cm]": "0",
+                "End Offset[cm]": "1000",
+                "始点側線幅[cm]": "12",
+                "終点側線幅[cm]": "12",
+                "種別": "1",
+                "Is Retransmission": "false",
+            }
+        ]
+    )
+
+    line_geometry_lookup = {
+        "100": [
+            {
+                "s": [0.0, 5.0, 10.0],
+                "x": [0.0, 5.0, 10.0],
+                "y": [0.0, 0.0, 0.0],
+                "z": [0.0, 0.0, 0.0],
+            }
+        ]
+    }
+
+    specs = build_lane_spec(
+        sections,
+        _make_lane_topology("100"),
+        defaults={},
+        lane_div_df=lane_div,
+        line_geometry_lookup=line_geometry_lookup,
+    )
+
+    first_lane = specs[0]["left"][0]
+    assert first_lane["roadMark"]["type"] == "solid"
+    assert first_lane["roadMark"]["width"] == pytest.approx(0.12)
+    geom_first = first_lane["roadMark"].get("geometry")
+    assert geom_first is not None
+    assert geom_first["s"][0] == pytest.approx(0.0)
+    assert geom_first["s"][-1] == pytest.approx(4.0)
+    assert geom_first["x"][-1] == pytest.approx(4.0)
+
+    second_lane = specs[1]["left"][0]
+    geom_second = second_lane["roadMark"]["geometry"]
+    assert geom_second["s"][0] == pytest.approx(4.0)
+    assert geom_second["s"][-1] == pytest.approx(10.0)
+    assert geom_second["x"][0] == pytest.approx(4.0)

--- a/tests/test_lane_spec_links.py
+++ b/tests/test_lane_spec_links.py
@@ -71,7 +71,7 @@ def test_lane_spec_flags_and_writer_links(tmp_path):
             },
             "B:1": {
                 "base_id": "B",
-                "lane_no": 1,
+                "lane_no": -1,
                 "segments": [
                     {
                         "start": 0.0,

--- a/tests/test_line_geometry.py
+++ b/tests/test_line_geometry.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from csv2xodr.line_geometry import build_line_geometry_lookup
+from csv2xodr.simpletable import DataFrame
+
+
+def test_build_line_geometry_lookup_deduplicates_retransmissions():
+    df = DataFrame(
+        [
+            {
+                "ライン型地物ID": "1.0e2",
+                "Offset[cm]": "100",
+                "緯度[deg]": "35.0",
+                "経度[deg]": "139.0",
+                "高さ[m]": "0.0",
+                "ログ時刻": "t1",
+                "Type": "1",
+                "Is Retransmission": "false",
+            },
+            {
+                "ライン型地物ID": "1.0e2",
+                "Offset[cm]": "200",
+                "緯度[deg]": "35.00001",
+                "経度[deg]": "139.00001",
+                "高さ[m]": "0.0",
+                "ログ時刻": "t1",
+                "Type": "1",
+                "Is Retransmission": "false",
+            },
+            {
+                "ライン型地物ID": "1.0e2",
+                "Offset[cm]": "300",
+                "緯度[deg]": "35.00002",
+                "経度[deg]": "139.00002",
+                "高さ[m]": "0.0",
+                "ログ時刻": "t2",
+                "Type": "1",
+                "Is Retransmission": "false",
+            },
+            {
+                "ライン型地物ID": "1.0e2",
+                "Offset[cm]": "400",
+                "緯度[deg]": "35.00003",
+                "経度[deg]": "139.00003",
+                "高さ[m]": "0.0",
+                "ログ時刻": "t2",
+                "Type": "1",
+                "Is Retransmission": "false",
+            },
+            {
+                "ライン型地物ID": "1.0e2",
+                "Offset[cm]": "100",
+                "緯度[deg]": "35.0",
+                "経度[deg]": "139.0",
+                "高さ[m]": "0.0",
+                "ログ時刻": "t3",
+                "Type": "1",
+                "Is Retransmission": "false",
+            },
+            {
+                "ライン型地物ID": "1.0e2",
+                "Offset[cm]": "200",
+                "緯度[deg]": "35.00001",
+                "経度[deg]": "139.00001",
+                "高さ[m]": "0.0",
+                "ログ時刻": "t3",
+                "Type": "1",
+                "Is Retransmission": "false",
+            },
+            {
+                "ライン型地物ID": "2.0e2",
+                "Offset[cm]": "100",
+                "緯度[deg]": "35.1",
+                "経度[deg]": "139.1",
+                "高さ[m]": "0.0",
+                "ログ時刻": "t4",
+                "Type": "1",
+                "Is Retransmission": "true",
+            },
+        ]
+    )
+
+    lookup = build_line_geometry_lookup(
+        df, offset_mapper=lambda value: value, lat0=35.0, lon0=139.0
+    )
+
+    assert sorted(lookup.keys()) == ["100"], "retransmitted geometry should be skipped"
+    assert len(lookup["100"]) == 2
+
+    first, second = lookup["100"]
+    assert first["s"][0] == pytest.approx(0.0)
+    assert first["s"][-1] == pytest.approx(1.0)
+    assert second["s"][0] == pytest.approx(2.0)
+    assert second["s"][-1] == pytest.approx(3.0)
+
+    assert first["z"] == [0.0, 0.0]
+    assert second["z"] == [0.0, 0.0]


### PR DESCRIPTION
## Summary
- parse PROFILETYPE_MPU_LINE_GEOMETRY.csv into canonical line geometry polylines and map them into the local XY frame
- feed parsed line geometry into lane spec generation to attach clipped road mark polylines and avoid merging distinct physical lines
- add regression tests covering geometry parsing, clipping, and lane spec integration

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d0d4ca05748327abb714c70d76e0e1