### PR TITLE
Add elevation profile generation from line geometry

### DIFF
--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -10,7 +10,7 @@ if __package__ is None or __package__ == "":
         sys.path.insert(0, str(ROOT))
 
 from csv2xodr.ingest.loader import load_all
-from csv2xodr.normalize.core import build_centerline, build_offset_mapper
+from csv2xodr.normalize.core import build_centerline, build_offset_mapper, build_elevation_profile
 from csv2xodr.line_geometry import build_line_geometry_lookup
 from csv2xodr.topology.core import make_sections, build_lane_topology
 from csv2xodr.writer.xodr_writer import write_xodr
@@ -58,10 +58,20 @@ def main():
         offset_mapper=offset_mapper,
     )
 
+    # vertical profile from line geometry heights
+    elevation_profile = build_elevation_profile(dfs["line_geometry"], offset_mapper=offset_mapper)
+
     # write xodr
     os.makedirs(os.path.dirname(args.output), exist_ok=True)
     geo_ref = f"LOCAL_XY origin={lat0},{lon0}"
-    output_path = write_xodr(center, sections, lane_specs, args.output, geo_ref=geo_ref)
+    output_path = write_xodr(
+        center,
+        sections,
+        lane_specs,
+        args.output,
+        geo_ref=geo_ref,
+        elevation_profile=elevation_profile,
+    )
 
     output_path = Path(output_path)
     try:

--- a/tests/test_elevation_profile.py
+++ b/tests/test_elevation_profile.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from csv2xodr.normalize.core import build_elevation_profile
+from csv2xodr.simpletable import DataFrame
+
+
+def test_build_elevation_profile_averages_and_slopes():
+    rows = [
+        {
+            "Offset[cm]": "0",
+            "高さ[m]": "10.0",
+            "Path Id": "1",
+            "Is Retransmission": "False",
+        },
+        {
+            "Offset[cm]": "100",
+            "高さ[m]": "12.0",
+            "Path Id": "1",
+            "Is Retransmission": "False",
+        },
+        {
+            "Offset[cm]": "100",
+            "高さ[m]": "14.0",
+            "Path Id": "1",
+            "Is Retransmission": "False",
+        },
+        {
+            "Offset[cm]": "200",
+            "高さ[m]": "20.0",
+            "Path Id": "2",
+            "Is Retransmission": "False",
+        },
+        {
+            "Offset[cm]": "200",
+            "高さ[m]": "15.0",
+            "Path Id": "1",
+            "Is Retransmission": "True",
+        },
+    ]
+    df = DataFrame(rows)
+
+    profile = build_elevation_profile(df)
+
+    assert len(profile) == 2
+    first, second = profile
+
+    assert first["s"] == 0.0
+    assert first["a"] == 10.0
+    assert first["b"] == 3.0  # (13 - 10) / (1 - 0)
+
+    assert second["s"] == 1.0
+    assert second["a"] == 13.0  # average of 12 and 14
+    assert second["b"] == 3.0  # inherits slope from previous segment


### PR DESCRIPTION
## Summary
- derive an OpenDRIVE elevation profile from line geometry heights and feed it through the conversion pipeline
- extend the writer to emit `<elevation>` segments when elevation data is available
- cover the new elevation helper with a focused unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a87bc29c8327a3d473b712638fd9