### PR TITLE
Normalize elevation offsets before mapping

### DIFF
--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -10,7 +10,7 @@ if __package__ is None or __package__ == "":
         sys.path.insert(0, str(ROOT))
 
 from csv2xodr.ingest.loader import load_all
-from csv2xodr.normalize.core import build_centerline, build_offset_mapper
+from csv2xodr.normalize.core import build_centerline, build_offset_mapper, build_elevation_profile
 from csv2xodr.line_geometry import build_line_geometry_lookup
 from csv2xodr.topology.core import make_sections, build_lane_topology
 from csv2xodr.writer.xodr_writer import write_xodr
@@ -58,10 +58,20 @@ def main():
         offset_mapper=offset_mapper,
     )
 
+    # vertical profile from line geometry heights
+    elevation_profile = build_elevation_profile(dfs["line_geometry"], offset_mapper=offset_mapper)
+
     # write xodr
     os.makedirs(os.path.dirname(args.output), exist_ok=True)
     geo_ref = f"LOCAL_XY origin={lat0},{lon0}"
-    output_path = write_xodr(center, sections, lane_specs, args.output, geo_ref=geo_ref)
+    output_path = write_xodr(
+        center,
+        sections,
+        lane_specs,
+        args.output,
+        geo_ref=geo_ref,
+        elevation_profile=elevation_profile,
+    )
 
     output_path = Path(output_path)
     try:

--- a/csv2xodr/normalize/core.py
+++ b/csv2xodr/normalize/core.py
@@ -1,11 +1,20 @@
 import math
-from typing import Callable, Iterable, List, Tuple
+from typing import Callable, Iterable, List, Tuple, Optional
 
 from csv2xodr.simpletable import DataFrame
 
 def _col_like(df: DataFrame, keyword: str):
     cols = [c for c in df.columns if keyword in c]
     return cols[0] if cols else None
+
+
+def _find_height_column(df: DataFrame) -> Optional[str]:
+    for col in df.columns:
+        stripped = col.strip()
+        lowered = stripped.lower()
+        if "高さ" in stripped or "標高" in stripped or "height" in lowered or "[m]" in stripped:
+            return col
+    return None
 
 def latlon_to_local_xy(lat: Iterable[float], lon: Iterable[float], lat0: float, lon0: float) -> Tuple[List[float], List[float]]:
     """
@@ -162,3 +171,130 @@ def build_offset_mapper(centerline: DataFrame) -> Callable[[float], float]:
         return s_vals[-1]
 
     return mapper
+
+
+def build_elevation_profile(
+    df_line_geo: DataFrame,
+    *,
+    offset_mapper: Optional[Callable[[float], float]] = None,
+) -> List[dict]:
+    """Build an OpenDRIVE elevation profile from line geometry heights.
+
+    The PROFILETYPE_MPU_LINE_GEOMETRY.csv source encodes longitudinal
+    offsets in centimetres alongside absolute height values.  The
+    resulting profile is emitted as a list of dictionaries ready to be
+    serialised into ``<elevation>`` elements where ``a`` represents the
+    height at ``s`` and ``b`` encodes the gradient (first derivative).
+    Only the primary path is considered when multiple polylines are
+    present in the input.
+    """
+
+    if df_line_geo is None or len(df_line_geo) == 0:
+        return []
+
+    offset_col = _col_like(df_line_geo, "Offset")
+    height_col = _find_height_column(df_line_geo)
+    if offset_col is None or height_col is None:
+        return []
+
+    path_col = _col_like(df_line_geo, "Path")
+    retrans_col: Optional[str] = None
+    for col in df_line_geo.columns:
+        if "retrans" in col.lower():
+            retrans_col = col
+            break
+
+    best_path = None
+    if path_col is not None and df_line_geo[path_col].nunique(dropna=True) > 1:
+        counts = {}
+        path_series = df_line_geo[path_col]
+        for value in path_series.to_list():
+            if value is None:
+                continue
+            counts[value] = counts.get(value, 0) + 1
+        if counts:
+            best_path = max(counts, key=counts.get)
+
+    grouped: dict = {}
+    for idx in range(len(df_line_geo)):
+        row = df_line_geo.iloc[idx]
+
+        if retrans_col is not None:
+            retrans_value = row[retrans_col]
+            if isinstance(retrans_value, str):
+                retrans_flag = retrans_value.strip().lower() == "true"
+            else:
+                retrans_flag = bool(retrans_value)
+            if retrans_flag:
+                continue
+
+        if best_path is not None and row[path_col] != best_path:
+            continue
+
+        offset_raw = row[offset_col]
+        height_raw = row[height_col]
+        try:
+            offset_cm = float(offset_raw)
+            height = float(height_raw)
+        except (TypeError, ValueError):
+            continue
+
+        grouped.setdefault(offset_cm, []).append(height)
+
+    if not grouped:
+        return []
+
+    sorted_offsets = sorted(grouped.keys())
+
+    # Normalize offsets relative to the first usable measurement so that
+    # both the elevation profile and the centerline mapper share the same
+    # origin.  When the raw offsets are provided in centimetres (a common
+    # case for PROFILETYPE_MPU_LINE_GEOMETRY) scale them down to metres to
+    # mirror the centreline rescaling logic.
+    start_offset_cm = sorted_offsets[0]
+    max_delta_cm = max((value - start_offset_cm) for value in sorted_offsets)
+    if offset_col and "cm" in offset_col.lower():
+        scale = 0.01
+    elif max_delta_cm > 1000.0:
+        scale = 0.01
+    else:
+        scale = 1.0
+
+    points: List[Tuple[float, float]] = []
+    for offset_cm in sorted_offsets:
+        heights = grouped[offset_cm]
+        if not heights:
+            continue
+        avg_height = sum(heights) / len(heights)
+        offset_norm = (offset_cm - start_offset_cm) * scale
+        if offset_mapper is not None:
+            s_val = float(offset_mapper(offset_norm))
+        else:
+            s_val = float(offset_norm)
+        points.append((s_val, avg_height))
+
+    if not points:
+        return []
+
+    profile: List[dict] = []
+    for idx, (s_val, height) in enumerate(points):
+        if idx < len(points) - 1:
+            next_s, next_height = points[idx + 1]
+            if next_s > s_val:
+                slope = (next_height - height) / (next_s - s_val)
+            else:
+                slope = 0.0
+        elif profile:
+            slope = profile[-1]["b"]
+        else:
+            slope = 0.0
+
+        profile.append({
+            "s": s_val,
+            "a": height,
+            "b": slope,
+            "c": 0.0,
+            "d": 0.0,
+        })
+
+    return profile

--- a/tests/test_elevation_profile.py
+++ b/tests/test_elevation_profile.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from csv2xodr.normalize.core import build_elevation_profile
+from csv2xodr.simpletable import DataFrame
+
+
+def test_build_elevation_profile_averages_and_slopes():
+    rows = [
+        {
+            "Offset[cm]": "0",
+            "高さ[m]": "10.0",
+            "Path Id": "1",
+            "Is Retransmission": "False",
+        },
+        {
+            "Offset[cm]": "100",
+            "高さ[m]": "12.0",
+            "Path Id": "1",
+            "Is Retransmission": "False",
+        },
+        {
+            "Offset[cm]": "100",
+            "高さ[m]": "14.0",
+            "Path Id": "1",
+            "Is Retransmission": "False",
+        },
+        {
+            "Offset[cm]": "200",
+            "高さ[m]": "20.0",
+            "Path Id": "2",
+            "Is Retransmission": "False",
+        },
+        {
+            "Offset[cm]": "200",
+            "高さ[m]": "15.0",
+            "Path Id": "1",
+            "Is Retransmission": "True",
+        },
+    ]
+    df = DataFrame(rows)
+
+    profile = build_elevation_profile(df)
+
+    assert len(profile) == 2
+    first, second = profile
+
+    assert first["s"] == 0.0
+    assert first["a"] == 10.0
+    assert first["b"] == 3.0  # (13 - 10) / (1 - 0)
+
+    assert second["s"] == 1.0
+    assert second["a"] == 13.0  # average of 12 and 14
+    assert second["b"] == 3.0  # inherits slope from previous segment
+
+
+def test_build_elevation_profile_aligns_offsets_with_mapper():
+    rows = [
+        {"Offset[cm]": "10000", "height[m]": "0.0"},
+        {"Offset[cm]": "10100", "height[m]": "1.0"},
+        {"Offset[cm]": "10200", "height[m]": "2.0"},
+    ]
+    df = DataFrame(rows)
+
+    class Recorder:
+        def __init__(self):
+            self.values = []
+
+        def __call__(self, value):
+            self.values.append(value)
+            return value * 2.0
+
+    mapper = Recorder()
+
+    profile = build_elevation_profile(df, offset_mapper=mapper)
+
+    assert mapper.values == [0.0, 1.0, 2.0]
+    assert [segment["s"] for segment in profile] == [0.0, 2.0, 4.0]


### PR DESCRIPTION
## Summary
- normalise elevation offsets against the first measurement and scale centimetre inputs to metres before computing gradients
- ensure the offset mapper receives centred, scaled values so elevation segments align with the plan view
- cover the normalisation behaviour with a regression-style unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3a87bc29c8327a3d473b712638fd9