### PR TITLE
Flatten terminal elevation slope

### DIFF
--- a/csv2xodr/normalize/core.py
+++ b/csv2xodr/normalize/core.py
@@ -268,9 +268,12 @@ def build_elevation_profile(
                 slope = (next_height - height) / (next_s - s_val)
             else:
                 slope = 0.0
-        elif profile:
-            slope = profile[-1]["b"]
         else:
+            # The final elevation entry does not have a following point to
+            # constrain its gradient.  Re-using the previous slope may cause
+            # the profile to extrapolate aggressively which manifests as a
+            # vertical spike at the end of the road.  Default to a flat
+            # continuation instead.
             slope = 0.0
 
         profile.append({

--- a/tests/test_elevation_profile.py
+++ b/tests/test_elevation_profile.py
@@ -57,4 +57,4 @@ def test_build_elevation_profile_averages_and_slopes():
 
     assert second["s"] == 1.0
     assert second["a"] == 13.0  # average of 12 and 14
-    assert second["b"] == 3.0  # inherits slope from previous segment
+    assert second["b"] == 0.0  # final segment flattens to avoid spikes


### PR DESCRIPTION
## Summary
- force the final elevation element to use a flat slope so generated roads no longer spike upwards at the end
- update the elevation profile test expectations to cover the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3acece9dc8327843e08febd347a65