### PR TITLE
Fix offset normalization for profiles

### DIFF
--- a/out/report.json
+++ b/out/report.json
@@ -13,13 +13,13 @@
   },
   "output_counts": {
     "roads": 1,
-    "laneSections": 21,
-    "lanes_total": 44,
-    "roadMark_segments_total": 23
+    "laneSections": 18,
+    "lanes_total": 108
   },
-  "size_bytes": {
-    "input_csv_total": 1048133,
-    "output_xodr": 6330,
-    "ratio_output_to_input": 0.006039
+  "road_length_m": 1403.1712753071367,
+  "xodr_file": {
+    "path": "/workspace/opendrive/out/sample.xodr",
+    "size_bytes": 38292,
+    "line_count": 948
   }
 }

--- a/out/sample.xodr
+++ b/out/sample.xodr
@@ -1,114 +1,948 @@
 <?xml version="1.0" encoding="utf-8"?>
 <OpenDRIVE>
-  <header revMajor="1" revMinor="4" name="csv2xodr" version="1.00" date="2025-09-17">
+  <header revMajor="1" revMinor="4" name="csv2xodr" version="1.00" date="2025-09-16">
     <geoReference>LOCAL_XY origin=36.23395354399317,139.57444950462656</geoReference>
   </header>
-  <road name="road_1" length="34188.240" id="1" junction="-1">
+  <road name="road_1" length="1403.171" id="1" junction="-1">
     <planView>
-      <geometry s="0.000" x="-1.776" y="0.373" hdg="1.351501" length="23735.380">
-        <line/>
-      </geometry>
-      <geometry s="23735.380" x="303.681" y="1011.074" hdg="1.083993" length="59.320">
+      <geometry s="0.000" x="8.049" y="29.608" hdg="1.346459" length="69.378">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="23794.700" x="276.198" y="949.193" hdg="1.097145" length="80.180">
+      <geometry s="69.378" x="23.483" y="97.248" hdg="1.346459" length="69.481">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="23874.880" x="296.216" y="989.053" hdg="1.089275" length="59.990">
+      <geometry s="138.860" x="37.194" y="165.363" hdg="1.372161" length="72.202">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="23934.870" x="266.263" y="954.082" hdg="1.108921" length="79.930">
+      <geometry s="211.062" x="51.126" y="236.208" hdg="1.376607" length="77.814">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24014.800" x="276.468" y="974.385" hdg="1.114426" length="79.810">
+      <geometry s="288.876" x="67.031" y="312.379" hdg="1.364960" length="81.172">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24094.610" x="269.695" y="952.626" hdg="1.124185" length="79.990">
+      <geometry s="370.047" x="84.557" y="391.636" hdg="1.353160" length="83.010">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24174.600" x="278.455" y="970.616" hdg="1.092944" length="78.050">
+      <geometry s="453.058" x="103.145" y="472.538" hdg="1.344956" length="72.031">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24252.650" x="263.705" y="955.351" hdg="1.098538" length="73.440">
+      <geometry s="525.088" x="121.188" y="542.273" hdg="1.317620" length="74.944">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24326.090" x="270.719" y="969.646" hdg="1.093506" length="79.110">
+      <geometry s="600.033" x="141.269" y="614.477" hdg="1.299537" length="81.409">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24405.200" x="276.709" y="948.931" hdg="1.118020" length="79.680">
+      <geometry s="681.442" x="165.378" y="692.234" hdg="1.270131" length="82.614">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24484.880" x="281.315" y="958.262" hdg="1.108279" length="80.060">
+      <geometry s="764.056" x="192.808" y="770.161" hdg="1.232350" length="77.104">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24564.940" x="273.007" y="950.835" hdg="1.109825" length="79.860">
+      <geometry s="841.160" x="221.084" y="841.893" hdg="1.195308" length="79.382">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24644.800" x="281.947" y="968.824" hdg="1.102017" length="80.220">
+      <geometry s="920.542" x="253.105" y="914.531" hdg="1.155594" length="80.900">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24725.020" x="276.198" y="949.193" hdg="1.097145" length="79.560">
+      <geometry s="1001.442" x="288.868" y="987.097" hdg="1.112898" length="80.661">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24804.580" x="280.653" y="958.001" hdg="1.117171" length="80.570">
+      <geometry s="1082.103" x="327.017" y="1058.166" hdg="1.078155" length="78.864">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24885.150" x="302.808" y="1025.144" hdg="1.063181" length="79.910">
+      <geometry s="1160.968" x="367.245" y="1125.999" hdg="1.035506" length="81.808">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="24965.060" x="342.663" y="1095.386" hdg="-2.042505" length="79.900">
+      <geometry s="1242.775" x="411.675" y="1194.690" hdg="0.996660" length="80.075">
         <arc curvature="3.000000000"/>
       </geometry>
-      <geometry s="25044.960" x="306.089" y="1023.689" hdg="1.068758" length="80.310">
-        <arc curvature="3.000000000"/>
-      </geometry>
-      <geometry s="25125.270" x="345.974" y="1093.930" hdg="-2.167419" length="9062.970">
+      <geometry s="1322.850" x="457.812" y="1260.138" hdg="0.956771" length="80.321">
         <arc curvature="3.000000000"/>
       </geometry>
     </planView>
     <elevationProfile>
-      <elevation s="0.000" a="0.000000" b="-0.006500" c="0.0" d="0.0"/>
-      <elevation s="23735.380" a="0.000000" b="-0.006500" c="0.0" d="0.0"/>
-      <elevation s="23794.700" a="-0.385580" b="-0.006300" c="0.0" d="0.0"/>
-      <elevation s="23874.880" a="-0.890714" b="-0.007900" c="0.0" d="0.0"/>
-      <elevation s="23934.870" a="-1.364635" b="-0.006600" c="0.0" d="0.0"/>
-      <elevation s="24014.800" a="-1.892173" b="-0.006600" c="0.0" d="0.0"/>
-      <elevation s="24094.610" a="-2.418919" b="-0.004700" c="0.0" d="0.0"/>
-      <elevation s="24174.600" a="-2.794872" b="-0.002300" c="0.0" d="0.0"/>
-      <elevation s="24252.650" a="-2.974387" b="-0.004600" c="0.0" d="0.0"/>
-      <elevation s="24326.090" a="-3.312211" b="-0.003100" c="0.0" d="0.0"/>
-      <elevation s="24405.200" a="-3.557452" b="0.000000" c="0.0" d="0.0"/>
-      <elevation s="24484.880" a="-3.557452" b="-0.001000" c="0.0" d="0.0"/>
-      <elevation s="24564.940" a="-3.637512" b="-0.000900" c="0.0" d="0.0"/>
-      <elevation s="24644.800" a="-3.709386" b="-0.001700" c="0.0" d="0.0"/>
-      <elevation s="24725.020" a="-3.845760" b="-0.001500" c="0.0" d="0.0"/>
-      <elevation s="24804.580" a="-3.965100" b="-0.002100" c="0.0" d="0.0"/>
-      <elevation s="24885.150" a="-4.134297" b="-0.001800" c="0.0" d="0.0"/>
-      <elevation s="24965.060" a="-4.278135" b="-0.001400" c="0.0" d="0.0"/>
-      <elevation s="25044.960" a="-4.389995" b="-0.000800" c="0.0" d="0.0"/>
-      <elevation s="25125.270" a="-4.454243" b="-0.000100" c="0.0" d="0.0"/>
+      <elevation s="0.000" a="0.000000" b="-0.007319" c="0.000000" d="0.000000"/>
+      <elevation s="69.378" a="-0.507784" b="-0.006167" c="0.000000" d="0.000000"/>
+      <elevation s="138.860" a="-0.936251" b="-0.007518" c="0.000000" d="0.000000"/>
+      <elevation s="211.062" a="-1.479063" b="-0.007309" c="0.000000" d="0.000000"/>
+      <elevation s="288.876" a="-2.047825" b="-0.006263" c="0.000000" d="0.000000"/>
+      <elevation s="370.047" a="-2.556201" b="-0.003635" c="0.000000" d="0.000000"/>
+      <elevation s="453.058" a="-2.857958" b="-0.002874" c="0.000000" d="0.000000"/>
+      <elevation s="525.088" a="-3.064980" b="-0.003282" c="0.000000" d="0.000000"/>
+      <elevation s="600.033" a="-3.310974" b="-0.002937" c="0.000000" d="0.000000"/>
+      <elevation s="681.442" a="-3.550076" b="-0.001494" c="0.000000" d="0.000000"/>
+      <elevation s="764.056" a="-3.673511" b="-0.002483" c="0.000000" d="0.000000"/>
+      <elevation s="841.160" a="-3.864986" b="-0.000484" c="0.000000" d="0.000000"/>
+      <elevation s="920.542" a="-3.903381" b="-0.001553" c="0.000000" d="0.000000"/>
+      <elevation s="1001.442" a="-4.029014" b="-0.001484" c="0.000000" d="0.000000"/>
+      <elevation s="1082.103" a="-4.148689" b="-0.001325" c="0.000000" d="0.000000"/>
+      <elevation s="1160.968" a="-4.253223" b="-0.001553" c="0.000000" d="0.000000"/>
+      <elevation s="1242.775" a="-4.380265" b="-0.000235" c="0.000000" d="0.000000"/>
+      <elevation s="1322.850" a="-4.399106" b="-0.002035" c="0.000000" d="0.000000"/>
     </elevationProfile>
     <lateralProfile>
-      <superelevation s="0.000" a="0.019498" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="23735.380" a="0.019498" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="23794.700" a="0.015499" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="23874.880" a="-0.010100" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="23934.870" a="-0.021896" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24014.800" a="-0.017798" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24094.610" a="-0.013599" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24174.600" a="-0.025295" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24252.650" a="-0.014899" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24326.090" a="-0.026194" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24405.200" a="-0.025794" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24484.880" a="-0.023496" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24564.940" a="-0.025295" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24644.800" a="-0.018598" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24725.020" a="-0.027893" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24804.580" a="-0.030690" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24885.150" a="-0.020197" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="24965.060" a="-0.020897" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="25044.960" a="-0.026894" b="0.0" c="0.0" d="0.0"/>
-      <superelevation s="25125.270" a="-0.017398" b="0.0" c="0.0" d="0.0"/>
+      <superelevation s="0.000" a="0.024000" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="69.378" a="0.022629" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="138.860" a="-0.001979" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="211.062" a="-0.017054" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="288.876" a="-0.020417" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="370.047" a="-0.016846" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="453.058" a="-0.021972" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="525.088" a="-0.024688" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="600.033" a="-0.023937" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="681.442" a="-0.024708" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="764.056" a="-0.025783" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="841.160" a="-0.023818" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="920.542" a="-0.025353" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="1001.442" a="-0.027294" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="1082.103" a="-0.027024" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="1160.968" a="-0.030061" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="1242.775" a="-0.029516" b="0.000000" c="0.000000" d="0.000000"/>
+      <superelevation s="1322.850" a="-0.028637" b="0.000000" c="0.000000" d="0.000000"/>
     </lateralProfile>
+    <lanes>
+      <laneSection s="0.000">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.600" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.770" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.610" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.386" b="0" c="0" d="0"/>
+            <link>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.244" b="0" c="0" d="0"/>
+            <link>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="69.378">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.610" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.770" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.600" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.333" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.245" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="138.860">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.600" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.760" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.590" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.348" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.252" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="211.062">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.570" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.780" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.610" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.374" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.304" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="288.876">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.560" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.900" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.316" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.314" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="370.047">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.570" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.850" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.640" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.292" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.343" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="453.058">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.590" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.820" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.580" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.373" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.356" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="525.088">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.610" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.780" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.580" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.534" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.326" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="600.033">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.620" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.780" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.377" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.317" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="681.442">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.750" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.790" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.660" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.313" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.254" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="764.056">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.720" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.740" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.620" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.521" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.247" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="841.160">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.730" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.620" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.536" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.286" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="920.542">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.660" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.780" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.620" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.458" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.293" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="1001.442">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.830" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.570" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.428" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.295" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="1082.103">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.590" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.770" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.610" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.484" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.315" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="1160.968">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.590" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.750" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.640" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.501" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.294" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="1242.775">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.600" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.730" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.670" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.518" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+              <successor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.331" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+              <successor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+      <laneSection s="1322.850">
+        <center>
+          <lane id="0" type="none" level="false"/>
+        </center>
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.590" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.760" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.690" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.492" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="1000"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1000" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.327" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-1000"/>
+            </link>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>
   </road>
 </OpenDRIVE>


### PR DESCRIPTION
## Summary
- normalise the longitudinal offsets from curvature, slope, elevation and shoulder CSVs so they align with the generated centreline before mapping to s
- regenerate the sample OpenDRIVE and report to reflect the corrected profiles and shoulder widths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3b697174883279e2e951abbb79e31