### PR TITLE
Add road type metadata to generated XODR

### DIFF
--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -88,6 +88,18 @@ def main():
     # write xodr
     os.makedirs(os.path.dirname(args.output), exist_ok=True)
     geo_ref = f"LOCAL_XY origin={lat0},{lon0}"
+    road_cfg_raw = cfg.get("road") or {}
+    if not isinstance(road_cfg_raw, dict):
+        raise TypeError("road configuration must be a mapping if provided")
+
+    road_cfg = {
+        "type": road_cfg_raw.get("type", "town"),
+    }
+    if "speed" in road_cfg_raw:
+        road_cfg["speed"] = road_cfg_raw["speed"]
+    else:
+        road_cfg["speed"] = {"max": 50 / 3.6, "unit": "m/s"}
+
     output_path = write_xodr(
         center,
         sections,
@@ -97,6 +109,7 @@ def main():
         elevation_profile=elevation_profile,
         geometry_segments=geometry_segments,
         superelevation_profile=superelevation_profile,
+        road_metadata=road_cfg,
     )
 
     output_path = Path(output_path)

--- a/out/report.json
+++ b/out/report.json
@@ -19,7 +19,7 @@
   "road_length_m": 1403.1712753071367,
   "xodr_file": {
     "path": "/workspace/opendrive/out/sample.xodr",
-    "size_bytes": 38292,
-    "line_count": 948
+    "size_bytes": 38377,
+    "line_count": 951
   }
 }

--- a/out/sample.xodr
+++ b/out/sample.xodr
@@ -4,6 +4,9 @@
     <geoReference>LOCAL_XY origin=36.23395354399317,139.57444950462656</geoReference>
   </header>
   <road name="road_1" length="1403.171" id="1" junction="-1">
+    <type s="0.0" type="town">
+      <speed max="13.888889" unit="m/s"/>
+    </type>
     <planView>
       <geometry s="0.000" x="8.049" y="29.608" hdg="1.346459" length="69.378">
         <arc curvature="3.000000000"/>


### PR DESCRIPTION
## Summary
- ensure the command line wrapper always passes road metadata to the writer and supply sensible defaults
- teach the XODR writer to emit a <type> element with optional speed information so viewers can render the map
- update the generated sample artifacts to include the new road metadata

## Testing
- python csv2xodr/csv2xodr.py --input ./input_csv --output ./out/sample.xodr --config ./csv2xodr/config.yaml
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3b8dc12cc8327a7001db3b8987935