### PR TITLE
Fix shoulder lane IDs for OpenDRIVE export

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -539,8 +539,33 @@ def apply_shoulder_profile(
     left_prev: Optional[Dict[str, Any]] = None
     right_prev: Optional[Dict[str, Any]] = None
 
-    LEFT_ID = 1000
-    RIGHT_ID = -1000
+    def _existing_lane_ids(side: str) -> List[int]:
+        ids: List[int] = []
+        for section in lane_sections:
+            for lane in section.get(side, []):
+                try:
+                    lane_id = int(lane.get("id"))
+                except (TypeError, ValueError):
+                    continue
+                ids.append(lane_id)
+        return ids
+
+    left_ids = _existing_lane_ids("left")
+    right_ids = _existing_lane_ids("right")
+
+    if left_ids:
+        LEFT_ID = max(left_ids) + 1
+        if LEFT_ID <= 0:
+            LEFT_ID = 1
+    else:
+        LEFT_ID = 1
+
+    if right_ids:
+        RIGHT_ID = min(right_ids) - 1
+        if RIGHT_ID >= 0:
+            RIGHT_ID = -1
+    else:
+        RIGHT_ID = -1
 
     for section in lane_sections:
         s0 = section.get("s0", 0.0)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -98,5 +98,7 @@ def test_apply_shoulder_profile_adds_lanes():
     assert right_lanes and right_lanes[0]["width"] == 1.5
 
     next_left = [lane for lane in lane_sections[1]["left"] if lane["type"] == "shoulder"][0]
-    assert next_left["predecessors"] == [1000]
-    assert left_lanes[0]["successors"] == [1000]
+    left_shoulder_id = next_left["id"]
+    assert left_shoulder_id not in {lane["id"] for lane in lane_sections[0]["left"] if lane["type"] != "shoulder"}
+    assert next_left["predecessors"] == [left_shoulder_id]
+    assert left_lanes[0]["successors"] == [left_shoulder_id]


### PR DESCRIPTION
## Summary
- derive shoulder lane IDs from existing lane numbering so exported OpenDRIVE files keep contiguous lane identifiers
- update the shoulder profile unit test to validate the new dynamic IDs and link propagation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3cefcf8f88327b0d93b1f70bb220c