### PR TITLE
Make curvature fallback tolerance configurable

### DIFF
--- a/csv2xodr/config.yaml
+++ b/csv2xodr/config.yaml
@@ -23,6 +23,9 @@ defaults:
   lane_width_m: 3.5
   shoulder_width_m: 0.5
 
+geometry:
+  max_endpoint_deviation_m: 0.5
+
 dedupe:
   enabled: true
   ds_thresh: 0.001      # meters

--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -69,7 +69,22 @@ def main():
     )
 
     curvature_profile = build_curvature_profile(dfs.get("curvature"), offset_mapper=offset_mapper)
-    geometry_segments = build_geometry_segments(center, curvature_profile)
+
+    geometry_cfg_raw = cfg.get("geometry") or {}
+    if not isinstance(geometry_cfg_raw, dict):
+        raise TypeError("geometry configuration must be a mapping if provided")
+
+    max_endpoint_deviation_cfg = geometry_cfg_raw.get("max_endpoint_deviation_m", 0.5)
+    try:
+        max_endpoint_deviation = float(max_endpoint_deviation_cfg)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("geometry.max_endpoint_deviation_m must be a number") from exc
+
+    geometry_segments = build_geometry_segments(
+        center,
+        curvature_profile,
+        max_endpoint_deviation=max_endpoint_deviation,
+    )
 
     slope_profiles = build_slope_profile(dfs.get("slope"), offset_mapper=offset_mapper)
     longitudinal = slope_profiles.get("longitudinal", [])

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -71,6 +71,41 @@ def test_geometry_segments_from_curvature():
     assert geometry[1]["curvature"] == 0.1
 
 
+def test_geometry_segments_respect_threshold():
+    center = DataFrame({
+        "s": [0.0, 1.0],
+        "x": [0.0, 1.0],
+        "y": [0.0, 0.0],
+        "hdg": [0.0, 0.0],
+    })
+
+    curvature_df = DataFrame(
+        {
+            "Offset[cm]": [0],
+            "End Offset[cm]": [100],
+            "曲率値[rad/m]": [0.2],
+            "Is Retransmission": ["False"],
+        }
+    )
+
+    curvature_segments = build_curvature_profile(curvature_df)
+
+    strict_geometry = build_geometry_segments(
+        center,
+        curvature_segments,
+        max_endpoint_deviation=0.05,
+    )
+
+    assert strict_geometry == []
+
+    relaxed_geometry = build_geometry_segments(
+        center,
+        curvature_segments,
+        max_endpoint_deviation=0.5,
+    )
+
+    assert len(relaxed_geometry) == 1
+
 def test_apply_shoulder_profile_adds_lanes():
     lane_sections = [
         {"s0": 0.0, "s1": 10.0, "left": [{"id": 1, "width": 3.5, "roadMark": {}, "predecessors": [], "successors": [], "type": "driving"}], "right": [{"id": -1, "width": 3.5, "roadMark": {}, "predecessors": [], "successors": [], "type": "driving"}]},


### PR DESCRIPTION
## Summary
- add a geometry section to the config so the curvature endpoint tolerance can be tuned
- allow csv2xodr to read the tolerance and forward it to the geometry segment builder
- expose the tolerance as an argument in build_geometry_segments and cover it with a unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f5127e688327aa956d110f7d0adc