### PR TITLE
Make geometry densification configurable

### DIFF
--- a/csv2xodr/config.yaml
+++ b/csv2xodr/config.yaml
@@ -25,6 +25,7 @@ defaults:
 
 geometry:
   max_endpoint_deviation_m: 0.5
+  max_segment_length_m: 2.0
 
 dedupe:
   enabled: true

--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -80,10 +80,17 @@ def main():
     except (TypeError, ValueError) as exc:
         raise TypeError("geometry.max_endpoint_deviation_m must be a number") from exc
 
+    max_segment_length_cfg = geometry_cfg_raw.get("max_segment_length_m", 2.0)
+    try:
+        max_segment_length = float(max_segment_length_cfg)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("geometry.max_segment_length_m must be a number") from exc
+
     geometry_segments = build_geometry_segments(
         center,
         curvature_profile,
         max_endpoint_deviation=max_endpoint_deviation,
+        max_segment_length=max_segment_length,
     )
 
     slope_profiles = build_slope_profile(dfs.get("slope"), offset_mapper=offset_mapper)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -189,6 +189,27 @@ def test_geometry_segments_are_densified_for_long_spans():
     assert len(geometry) >= 50
     assert all(seg["length"] <= 2.0 + 1e-9 for seg in geometry)
 
+
+def test_geometry_segments_honours_custom_densify_threshold():
+    center = DataFrame(
+        {
+            "s": [0.0, 50.0, 100.0],
+            "x": [0.0, 50.0, 100.0],
+            "y": [0.0, 0.0, 0.0],
+            "hdg": [0.0, 0.0, 0.0],
+        }
+    )
+
+    geometry = build_geometry_segments(
+        center,
+        [{"s0": 0.0, "s1": 100.0, "curvature": 0.0}],
+        max_endpoint_deviation=0.5,
+        max_segment_length=5.0,
+    )
+
+    assert len(geometry) >= 20
+    assert all(seg["length"] <= 5.0 + 1e-9 for seg in geometry)
+
 def test_apply_shoulder_profile_adds_lanes():
     lane_sections = [
         {"s0": 0.0, "s1": 10.0, "left": [{"id": 1, "width": 3.5, "roadMark": {}, "predecessors": [], "successors": [], "type": "driving"}], "right": [{"id": -1, "width": 3.5, "roadMark": {}, "predecessors": [], "successors": [], "type": "driving"}]},


### PR DESCRIPTION
## Summary
- allow configuring the maximum curvature-segment length used to densify planView arcs
- pass the new value from `csv2xodr.py` by reading `geometry.max_segment_length_m`
- add regression coverage for the configurability and document the new knob in config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5c82c97588327b0fee96b0545cc20