### PR TITLE
Refine curvature fitting to keep OpenDRIVE arcs

### DIFF
--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -99,7 +99,19 @@ def test_geometry_segments_respect_threshold():
         max_endpoint_deviation=0.01,
     )
 
-    assert strict_geometry == []
+    assert len(strict_geometry) >= 1
+
+    seg = strict_geometry[0]
+    if abs(seg.get("curvature", 0.0)) <= 1e-12:
+        end_x = seg["x"] + seg["length"] * math.cos(seg["hdg"])
+        end_y = seg["y"] + seg["length"] * math.sin(seg["hdg"])
+    else:
+        radius = 1.0 / seg["curvature"]
+        end_hdg = seg["hdg"] + seg["curvature"] * seg["length"]
+        end_x = seg["x"] + radius * (math.sin(end_hdg) - math.sin(seg["hdg"]))
+        end_y = seg["y"] - radius * (math.cos(end_hdg) - math.cos(seg["hdg"]))
+
+    assert math.hypot(end_x - 1.0, end_y - 0.0) <= 0.01 + 1e-6
 
     relaxed_geometry = build_geometry_segments(
         center,


### PR DESCRIPTION
## Summary
- refine build_geometry_segments so constant-curvature segments numerically match the measured centreline instead of falling back to polylines
- adjust the refinement logic to respect the configured endpoint tolerance and retain original curvature when already within bounds
- update the geometry profile test to assert the tighter tolerance is satisfied without discarding arc segments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5e534a6ec8327a7e8ab2d42cd0945