### PR TITLE
Add US CSV conversion pipeline

### DIFF
--- a/csv2xodr/config_us.yaml
+++ b/csv2xodr/config_us.yaml
@@ -1,5 +1,28 @@
-# 占位配置文件：待US格式的CSV转换流程确定后再补充实际字段映射。
 encoding_priority:
   - utf-8
+  - cp932
+  - cp1252
 
-files: {}
+files:
+  map_base_point: PROFILE_MPU_MAP_DATA_BASE_POINT.csv
+  line_geometry: PROFILETYPE_MPU_US_LANE_LINE_GEOMETRY.csv
+  lane_link: PROFILETYPE_MPU_US_LANE_LINK_INFO.csv
+  lane_division: PROFILETYPE_MPU_US_LANE_LINE.csv
+  lane_width: PROFILETYPE_MPU_US_LANE_WIDTH.csv
+  curvature: PROFILETYPE_MPU_US_CURVATURE.csv
+  slope: PROFILETYPE_MPU_US_SLOPE.csv
+  sign: PROFILETYPE_MPU_US_SIGN.csv
+
+defaults:
+  lane_width_m: 3.6
+  shoulder_width_m: 0.5
+
+geometry:
+  max_endpoint_deviation_m: 0.75
+  max_segment_length_m: 2.5
+
+road:
+  type: motorway
+  speed:
+    max: 29.0576      # 約65 mph
+    unit: m/s

--- a/csv2xodr/line_geometry.py
+++ b/csv2xodr/line_geometry.py
@@ -57,7 +57,11 @@ def build_line_geometry_lookup(
 
     cols = list(line_geom_df.columns)
 
-    line_id_col = _find_column(cols, "ライン", "ID") or _find_column(cols, "区画線", "ID")
+    line_id_col = (
+        _find_column(cols, "ライン", "ID")
+        or _find_column(cols, "区画線", "ID")
+        or _find_column(cols, "lane", "line", "id")
+    )
     lat_col = _find_column(cols, "緯度") or _find_column(cols, "Latitude")
     lon_col = _find_column(cols, "経度") or _find_column(cols, "Longitude")
     z_col = _find_column(cols, "高さ") or _find_column(cols, "標高") or _find_column(cols, "Height")

--- a/csv2xodr/mapping/core.py
+++ b/csv2xodr/mapping/core.py
@@ -16,6 +16,17 @@ def mark_type_from_division_row(row: Series) -> str:
                 pass
 
     for c in row.index:
+        lowered = str(c).strip().lower()
+        if "lane line type" in lowered and notna(row[c]):
+            try:
+                v = int(float(str(row[c]).strip()))
+            except Exception:
+                continue
+            if v in (2, 3):
+                return "broken"
+            return "solid"
+
+    for c in row.index:
         if "種別" in c and notna(row[c]):
             try:
                 v = int(row[c])

--- a/csv2xodr/normalize/us_adapters.py
+++ b/csv2xodr/normalize/us_adapters.py
@@ -1,0 +1,109 @@
+"""Helpers that adapt US-specific CSV tables to the generic converter pipeline."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional
+
+from csv2xodr.simpletable import DataFrame
+from csv2xodr.topology.core import _canonical_numeric
+
+
+def _find_column(columns: Iterable[str], *keywords: str) -> Optional[str]:
+    lowered = [kw.lower() for kw in keywords]
+    for col in columns:
+        value = col.strip().lower()
+        if all(keyword in value for keyword in lowered):
+            return col
+    return None
+
+
+def _to_float(value) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if text == "" or text.lower() == "nan":
+            return None
+        return float(text)
+    except Exception:
+        return None
+
+
+def merge_lane_width_into_links(
+    lane_link_df: Optional[DataFrame], lane_width_df: Optional[DataFrame]
+) -> Optional[DataFrame]:
+    """Inject average lane widths (in centimetres) into the link table."""
+
+    if lane_link_df is None or len(lane_link_df) == 0:
+        return lane_link_df
+    if lane_width_df is None or len(lane_width_df) == 0:
+        return lane_link_df
+
+    width_lane_col = _find_column(lane_width_df.columns, "lane", "number")
+    width_value_col = None
+    for col in lane_width_df.columns:
+        lowered = col.strip().lower()
+        if "width" in lowered or "幅員" in col:
+            width_value_col = col
+            break
+
+    if width_lane_col is None or width_value_col is None:
+        return lane_link_df
+
+    totals: Dict[str, float] = {}
+    counts: Dict[str, int] = {}
+
+    for idx in range(len(lane_width_df)):
+        row = lane_width_df.iloc[idx]
+        lane_raw = row[width_lane_col]
+        lane_id = _canonical_numeric(lane_raw, allow_negative=True)
+        if lane_id is None:
+            lane_id = str(lane_raw).strip()
+        if not lane_id:
+            continue
+
+        width_val = _to_float(row[width_value_col])
+        if width_val is None or width_val <= 0:
+            continue
+
+        totals[lane_id] = totals.get(lane_id, 0.0) + width_val
+        counts[lane_id] = counts.get(lane_id, 0) + 1
+
+    if not totals:
+        return lane_link_df
+
+    width_map = {key: totals[key] / counts[key] for key in totals}
+
+    link_lane_col = _find_column(lane_link_df.columns, "lane", "number")
+    if link_lane_col is None:
+        link_lane_col = _find_column(lane_link_df.columns, "レーン", "番号")
+    if link_lane_col is None:
+        return lane_link_df
+
+    existing_columns = list(lane_link_df.columns)
+    width_col_name = "幅員"
+    if width_col_name not in existing_columns:
+        columns = existing_columns + [width_col_name]
+    else:
+        columns = existing_columns
+
+    new_rows = []
+    for idx in range(len(lane_link_df)):
+        src = lane_link_df.iloc[idx]
+        row = {col: src[col] for col in existing_columns}
+
+        lane_raw = src[link_lane_col]
+        lane_id = _canonical_numeric(lane_raw, allow_negative=True)
+        if lane_id is None:
+            lane_id = str(lane_raw).strip()
+
+        width_m = width_map.get(lane_id) if lane_id else None
+        if width_m is None and lane_raw in width_map:
+            width_m = width_map[lane_raw]
+
+        if width_m is not None:
+            row[width_col_name] = width_m * 100.0
+
+        new_rows.append(row)
+
+    return DataFrame(new_rows, columns=columns)

--- a/csv2xodr/topology/core.py
+++ b/csv2xodr/topology/core.py
@@ -152,7 +152,7 @@ def build_lane_topology(lane_link_df: DataFrame,
     line_pos_cols: Dict[int, str] = {}
     for col in cols:
         stripped = col.strip()
-        if "ライン型地物ID" in stripped:
+        if "ライン型地物ID" in stripped or ("lane line id" in stripped.lower() and "数" not in stripped):
             try:
                 idx = int(stripped.split("(")[1].split(")")[0])
             except Exception:

--- a/pythonProject/main.py
+++ b/pythonProject/main.py
@@ -1,10 +1,9 @@
 """Command line helper to convert CSV datasets into OpenDRIVE files.
 
 This script understands different CSV layouts (currently JPN and US) and
-dispatches them to their dedicated conversion pipeline.  The actual
-conversion logic for the JPN format delegates to ``csv2xodr.csv2xodr`` while
-the US workflow will be filled in a later step when the specification becomes
-available.
+dispatches them to their dedicated conversion pipeline.  Both formats reuse
+the conversion machinery in ``csv2xodr.csv2xodr`` while supplying their
+format-specific configuration files.
 """
 
 from __future__ import annotations
@@ -65,16 +64,9 @@ def build_pipeline_registry() -> Dict[str, FormatPipeline]:
 
 
 def _run_us_pipeline(input_dir: str, output_path: str, config_path: str) -> Dict:
-    """Placeholder for the US conversion pipeline.
+    """Execute the US-specific CSV → OpenDRIVE workflow."""
 
-    The real implementation will arrive once the processing details are
-    confirmed.  Raising ``NotImplementedError`` makes the limitation explicit
-    to users running the helper script.
-    """
-
-    raise NotImplementedError(
-        "US格式的CSV转换流程尚未实现，请在获取规格后再调用该格式。"
-    )
+    return convert_dataset(input_dir, output_path, config_path)
 
 
 def run_pipeline(pipeline: FormatPipeline) -> Dict:
@@ -112,7 +104,7 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
     parser.add_argument(
         "--all",
         action="store_true",
-        help="一次性转换所有支持的格式。US格式目前会提示暂未实现。",
+        help="一次性转换所有支持的格式。",
     )
 
     args = parser.parse_args(list(argv) if argv is not None else None)

--- a/tests/test_us_adapters.py
+++ b/tests/test_us_adapters.py
@@ -1,0 +1,31 @@
+import pytest
+
+from csv2xodr.normalize.us_adapters import merge_lane_width_into_links
+from csv2xodr.simpletable import DataFrame
+
+
+def test_merge_lane_width_into_links_injects_width_column():
+    lane_link = DataFrame(
+        [
+            {"Lane Number": "15", "Offset[cm]": "0", "End Offset[cm]": "100"},
+            {"Lane Number": "1", "Offset[cm]": "0", "End Offset[cm]": "100"},
+        ],
+        columns=["Lane Number", "Offset[cm]", "End Offset[cm]"],
+    )
+
+    lane_width = DataFrame(
+        [
+            {"Lane Number": "15", "幅員値[m]": "3.5"},
+            {"Lane Number": "15", "幅員値[m]": "3.7"},
+            {"Lane Number": "1", "幅員値[m]": "3.0"},
+        ],
+        columns=["Lane Number", "幅員値[m]"],
+    )
+
+    enriched = merge_lane_width_into_links(lane_link, lane_width)
+    assert enriched is not None
+    assert "幅員" in enriched.columns
+
+    widths = enriched["幅員"].to_list()
+    assert pytest.approx(widths[0], rel=1e-6) == 360.0
+    assert pytest.approx(widths[1], rel=1e-6) == 300.0


### PR DESCRIPTION
## Summary
- implement the US CSV conversion pipeline by reusing the shared converter
- add configuration, data post-processing, and parser updates for US-specific columns
- provide a unit test covering the new lane-width merge helper

## Testing
- pytest
- python pythonProject/main.py --format US

------
https://chatgpt.com/codex/tasks/task_e_68dc276e93808327b93b693ce4253750