### PR TITLE
Disable curvature input for US conversion

### DIFF
--- a/csv2xodr/config_us.yaml
+++ b/csv2xodr/config_us.yaml
@@ -9,7 +9,6 @@ files:
   lane_link: PROFILETYPE_MPU_US_LANE_LINK_INFO.csv
   lane_division: PROFILETYPE_MPU_US_LANE_LINE.csv
   lane_width: PROFILETYPE_MPU_US_LANE_WIDTH.csv
-  curvature: PROFILETYPE_MPU_US_CURVATURE.csv
   slope: PROFILETYPE_MPU_US_SLOPE.csv
   sign: PROFILETYPE_MPU_US_SIGN.csv
 


### PR DESCRIPTION
## Summary
- remove the curvature CSV reference from the US configuration so the export falls back to polyline geometry and avoids the viewer hang

## Testing
- python pythonProject/main.py --format US
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc3330b43c832788021dfc35a7badb