### PR TITLE
Fix US lane topology lane count handling

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -370,7 +370,7 @@ def build_lane_spec(
     positive_bases = _bases_with_sign(1)
     negative_bases = _bases_with_sign(-1)
 
-    if positive_bases or negative_bases:
+    if positive_bases and negative_bases:
         # When the input data contains explicit lane number signs we rely on
         # them to determine the side of the reference line.  This avoids
         # mis-classifying sequential lane groups that belong to the same

--- a/csv2xodr/topology/core.py
+++ b/csv2xodr/topology/core.py
@@ -140,7 +140,11 @@ def build_lane_topology(lane_link_df: DataFrame,
     end_col = _find_column(cols, "End", "Offset")
     lane_id_col = _find_column(cols, "レーンID") or _find_column(cols, "Lane", "ID")
     lane_no_col = _find_column(cols, "レーン番号") or _find_column(cols, "Lane", "番号")
-    lane_count_col = _find_column(cols, "Lane", "Number")
+    lane_count_col = (
+        _find_column(cols, "総数")
+        or _find_column(cols, "Count")
+        or _find_column(cols, "count")
+    )
     width_col = _find_column(cols, "幅員")
     is_retrans_col = _find_column(cols, "Is", "Retransmission")
     left_col = _find_column(cols, "左側車線")

--- a/tests/test_lane_spec_links.py
+++ b/tests/test_lane_spec_links.py
@@ -116,3 +116,48 @@ def test_lane_spec_flags_and_writer_links(tmp_path):
     assert last_right_link is not None
     assert last_right_link.find("predecessor").attrib["id"] == "-1"
     assert last_right_link.find("successor") is None
+
+
+def test_lane_spec_uses_lane_count_when_only_positive_lane_numbers():
+    sections = [{"s0": 0.0, "s1": 10.0}]
+
+    lane_topology = {
+        "lane_count": 4,
+        "groups": {
+            "A": ["A:1"],
+            "B": ["B:2"],
+            "C": ["C:3"],
+            "D": ["D:4"],
+        },
+        "lanes": {
+            "A:1": {
+                "base_id": "A",
+                "lane_no": 1,
+                "segments": [{"start": 0.0, "end": 10.0, "width": 3.5, "successors": [], "predecessors": [], "line_positions": {}}],
+            },
+            "B:2": {
+                "base_id": "B",
+                "lane_no": 2,
+                "segments": [{"start": 0.0, "end": 10.0, "width": 3.5, "successors": [], "predecessors": [], "line_positions": {}}],
+            },
+            "C:3": {
+                "base_id": "C",
+                "lane_no": 3,
+                "segments": [{"start": 0.0, "end": 10.0, "width": 3.5, "successors": [], "predecessors": [], "line_positions": {}}],
+            },
+            "D:4": {
+                "base_id": "D",
+                "lane_no": 4,
+                "segments": [{"start": 0.0, "end": 10.0, "width": 3.5, "successors": [], "predecessors": [], "line_positions": {}}],
+            },
+        },
+    }
+
+    specs = build_lane_spec(sections, lane_topology, defaults={}, lane_div_df=None)
+
+    assert len(specs) == 1
+    left_ids = [lane["id"] for lane in specs[0]["left"]]
+    right_ids = [lane["id"] for lane in specs[0]["right"]]
+
+    assert left_ids == [1, 2]
+    assert right_ids == [-1, -2]

--- a/tests/test_lane_topology.py
+++ b/tests/test_lane_topology.py
@@ -35,3 +35,28 @@ def test_build_lane_topology_prefers_true_retransmission_segments():
     segments = topology["lanes"]["A:1"]["segments"]
     assert len(segments) == 1
     assert segments[0]["is_retrans"] is True
+
+
+def test_build_lane_topology_reads_total_lane_count_column():
+    df = DataFrame(
+        [
+            {
+                "Offset[cm]": "0",
+                "End Offset[cm]": "100",
+                "レーンID": "A",
+                "レーン番号": "1",
+                "レーン総数": "4",
+            },
+            {
+                "Offset[cm]": "0",
+                "End Offset[cm]": "100",
+                "レーンID": "B",
+                "レーン番号": "2",
+                "レーン総数": "4",
+            },
+        ]
+    )
+
+    topology = build_lane_topology(df)
+
+    assert topology["lane_count"] == 4


### PR DESCRIPTION
## Summary
- fix lane count detection for US lane link tables and improve lane side fallback logic
- ensure lane sections distribute positive-only lane numbers using the configured lane count
- add regression tests covering the lane count column and fallback behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc4bcf8d00832799fe326aafd90bac