### PR TITLE
Relax curvature sign locking for noisy JPN curvature samples

### DIFF
--- a/csv2xodr/normalize/core.py
+++ b/csv2xodr/normalize/core.py
@@ -1111,10 +1111,13 @@ def build_geometry_segments(
             preferred_curvature = 0.0
             preferred_sign = 0.0
             if abs(curvature_dataset) > 1e-12:
-                agrees_with_target = True
-                if abs(delta_target) > 1e-6 and abs(delta_dataset) > 1e-9:
-                    agrees_with_target = delta_target * delta_dataset >= 0
-                if agrees_with_target:
+                alignment_error = abs(_normalize_angle(delta_target - delta_dataset))
+                # When the curvature samples are noisy the heading delta derived
+                # from the centreline provides a more reliable reference.  Only
+                # trust the CSV curvature if it produces a similar change in
+                # heading, otherwise allow the solver to determine the sign.
+                tolerance = max(5e-4, abs(delta_target) * 0.5)
+                if alignment_error <= tolerance:
                     preferred_curvature = curvature_dataset
                     preferred_sign = math.copysign(1.0, curvature_dataset)
 


### PR DESCRIPTION
## Summary
- only trust CSV curvature direction when the implied heading change matches the centreline
- allow the solver to pick the correct sign when the dataset disagrees to avoid broken plan-view segments

## Testing
- pytest
- python -m csv2xodr.csv2xodr --input input_csv/JPN --output out/jpn.xodr --config csv2xodr/config.yaml

------
https://chatgpt.com/codex/tasks/task_e_68dcc64b04bc832793efd06f533d981a