### PR TITLE
Relax curvature alignment tolerance for JPN profiles

### DIFF
--- a/csv2xodr/normalize/core.py
+++ b/csv2xodr/normalize/core.py
@@ -1116,7 +1116,10 @@ def build_geometry_segments(
                 # from the centreline provides a more reliable reference.  Only
                 # trust the CSV curvature if it produces a similar change in
                 # heading, otherwise allow the solver to determine the sign.
-                tolerance = max(5e-4, abs(delta_target) * 0.5)
+                base_tolerance = 1e-3
+                curvature_tolerance = abs(delta_dataset) * 0.25
+                target_tolerance = abs(delta_target) * 0.5
+                tolerance = max(base_tolerance, curvature_tolerance, target_tolerance)
                 if alignment_error <= tolerance:
                     preferred_curvature = curvature_dataset
                     preferred_sign = math.copysign(1.0, curvature_dataset)


### PR DESCRIPTION
## Summary
- relax the heading-alignment tolerance used when fitting curvature samples so JPN shape-index profiles keep their measured curvature
- derive the tolerance from both the dataset curvature and the centreline heading change to avoid snapping back to polylines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc9c9a5fc83278ad95ebc7d84f98e