### PR TITLE
Fix curvature scaling for shape index curvature segments

### DIFF
--- a/csv2xodr/normalize/core.py
+++ b/csv2xodr/normalize/core.py
@@ -716,7 +716,21 @@ def build_curvature_profile(
             if s1 <= s0:
                 continue
 
-            curvature_val = float(curv0)
+            dataset_span = offset1 - offset0
+            if dataset_span <= 0:
+                continue
+
+            s_span = s1 - s0
+            if s_span <= 0:
+                continue
+
+            curv0_val = float(curv0)
+            if not math.isfinite(curv0_val):
+                continue
+
+            scale = dataset_span / s_span if s_span > 1e-12 else 1.0
+            curvature_val = curv0_val * scale
+
             if not math.isfinite(curvature_val):
                 continue
 


### PR DESCRIPTION
## Summary
- rescale curvature samples derived from shape indices so their heading change matches the mapped centreline span
- skip invalid or zero-length subdivisions when building the curvature profile to avoid introducing jagged plan views

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcccb3a70883279f90673d6f81a6fc