### PR TITLE
Align curvature profile with centerline headings

### DIFF
--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -108,7 +108,9 @@ def convert_dataset(input_dir: str, output_path: str, config_path: str) -> dict:
         offset_mapper=offset_mapper,
     )
 
-    curvature_profile = build_curvature_profile(dfs.get("curvature"), offset_mapper=offset_mapper)
+    curvature_profile = build_curvature_profile(
+        dfs.get("curvature"), offset_mapper=offset_mapper, centerline=center
+    )
 
     geometry_cfg_raw = cfg.get("geometry") or {}
     if not isinstance(geometry_cfg_raw, dict):


### PR DESCRIPTION
## Summary
- scale the per-shape curvature buckets so that their integrated heading change matches the centerline
- plumb the centerline into the curvature builder to keep the planView smooth when shape indices are used

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcd804ba788327b23a627154d98563