### PR TITLE
Fix curvature alignment for JPN geometry

### DIFF
--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -49,12 +49,17 @@ def test_build_slope_profiles_and_elevation():
 
 
 def test_geometry_segments_from_curvature():
-    center = DataFrame({
-        "s": [0.0, 1.0, 2.0],
-        "x": [0.0, 1.0, 2.0],
-        "y": [0.0, 0.0, 0.0],
-        "hdg": [0.0, 0.0, 0.0],
-    })
+    # The centreline follows a straight 1 m segment and then a 0.1 rad/m arc
+    # so the curvature profile is geometrically consistent with the anchor
+    # points.
+    center = DataFrame(
+        {
+            "s": [0.0, 1.0, 2.0],
+            "x": [0.0, 1.0, 1.9983341664682815],
+            "y": [0.0, 0.0, 0.049958347219741794],
+            "hdg": [0.0, 0.0, 0.1],
+        }
+    )
 
     curvature_df = DataFrame(
         {


### PR DESCRIPTION
## Summary
- eliminate drift between numerically integrated geometry segments and the analytical centreline by always refining constant-curvature fits
- keep the previous curvature hint as a preference instead of forcing offsets, ensuring smooth arc output for JPN data
- update the geometry unit test to use a curvature-consistent centreline sample

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddcc6a1ad083279d9be3b234152f7f