### PR TITLE
Fix zero-length geometry segments causing OpenDRIVE gaps

### DIFF
--- a/tests/test_geometry_segments.py
+++ b/tests/test_geometry_segments.py
@@ -1,0 +1,38 @@
+from csv2xodr.normalize.core import _merge_geometry_segments
+
+
+def test_merge_geometry_segments_skips_zero_length_entries():
+    segments = [
+        {
+            "s": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "hdg": 0.0,
+            "length": 5.0,
+            "curvature": 0.0,
+        },
+        {
+            "s": 5.0,
+            "x": 5.0,
+            "y": 0.0,
+            "hdg": 0.0,
+            "length": 0.0,
+            "curvature": 0.0,
+        },
+        {
+            "s": 5.0,
+            "x": 5.0,
+            "y": 0.0,
+            "hdg": 0.5,
+            "length": 2.0,
+            "curvature": 0.1,
+        },
+    ]
+
+    merged = _merge_geometry_segments(segments)
+
+    assert len(merged) == 2
+    assert all(seg["length"] > 0 for seg in merged)
+    assert merged[0]["length"] == 5.0
+    assert merged[1]["s"] == 5.0
+    assert merged[1]["length"] == 2.0


### PR DESCRIPTION
## Summary
- filter out zero-length curvature segments before merging so plan view geometry stays continuous
- add a regression test to ensure `_merge_geometry_segments` discards zero-length entries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68de0899d33483278a7c37d91b11a199