### PR TITLE
Use lane geometry hints to stabilise lane orientation

### DIFF
--- a/csv2xodr/csv2xodr.py
+++ b/csv2xodr/csv2xodr.py
@@ -106,6 +106,9 @@ def convert_dataset(input_dir: str, output_path: str, config_path: str) -> dict:
         dfs["lane_division"],
         line_geometry_lookup=line_geometry_lookup,
         offset_mapper=offset_mapper,
+        lanes_geometry_df=dfs.get("lanes_geometry"),
+        centerline=center,
+        geo_origin=(lat0, lon0),
     )
 
     curvature_profile = build_curvature_profile(

--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -1,11 +1,13 @@
 """Helpers for building per-section lane specifications."""
 
+import math
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from csv2xodr.mapping.core import mark_type_from_division_row
 
 from csv2xodr.simpletable import DataFrame
 from csv2xodr.topology.core import _canonical_numeric
+from csv2xodr.normalize.core import latlon_to_local_xy
 
 
 def _clip_geometry_segment(geom: Dict[str, List[float]], s0: float, s1: float) -> Optional[Dict[str, List[float]]]:
@@ -111,9 +113,134 @@ def _lookup_line_segment(entry: Dict[str, Any], s0: float, s1: float) -> Tuple[O
     return selected, geom_segment
 
 
-def _build_division_lookup(lane_div_df: Optional[DataFrame],
-                           line_geometry_lookup: Optional[Dict[str, List[Dict[str, Any]]]] = None,
-                           offset_mapper=None) -> Dict[str, Dict[str, Any]]:
+def _interpolate_centerline_pose(centerline: DataFrame, target_s: float) -> Tuple[float, float, float]:
+    s_vals = [float(v) for v in centerline["s"].to_list()]
+    x_vals = [float(v) for v in centerline["x"].to_list()]
+    y_vals = [float(v) for v in centerline["y"].to_list()]
+    hdg_vals = [float(v) for v in centerline["hdg"].to_list()]
+
+    if not s_vals:
+        return 0.0, 0.0, 0.0
+
+    if target_s <= s_vals[0]:
+        return x_vals[0], y_vals[0], hdg_vals[0]
+
+    for idx in range(1, len(s_vals)):
+        s_prev = s_vals[idx - 1]
+        s_curr = s_vals[idx]
+        if target_s <= s_curr:
+            span = s_curr - s_prev
+            if span <= 0.0:
+                return x_vals[idx], y_vals[idx], hdg_vals[idx]
+            t = (target_s - s_prev) / span
+            x = x_vals[idx - 1] + t * (x_vals[idx] - x_vals[idx - 1])
+            y = y_vals[idx - 1] + t * (y_vals[idx] - y_vals[idx - 1])
+            if abs(target_s - s_curr) <= 1e-6:
+                hdg = hdg_vals[min(idx, len(hdg_vals) - 1)]
+            else:
+                hdg = hdg_vals[idx - 1]
+            return x, y, hdg
+
+    return x_vals[-1], y_vals[-1], hdg_vals[-1]
+
+
+def _estimate_lane_side_from_geometry(
+    lanes_geom_df: Optional[DataFrame],
+    centerline: Optional[DataFrame],
+    *,
+    offset_mapper=None,
+    geo_origin: Optional[Tuple[float, float]] = None,
+) -> Dict[str, str]:
+    if (
+        lanes_geom_df is None
+        or len(lanes_geom_df) == 0
+        or centerline is None
+        or len(centerline) == 0
+    ):
+        return {}
+
+    cols = list(lanes_geom_df.columns)
+
+    def find_col(*keywords: str) -> Optional[str]:
+        for col in cols:
+            stripped = col.strip()
+            if all(keyword in stripped for keyword in keywords):
+                return col
+        return None
+
+    lane_id_col = find_col("Lane", "ID") or find_col("レーンID")
+    lat_col = find_col("緯度") or find_col("Latitude")
+    lon_col = find_col("経度") or find_col("Longitude")
+    offset_col = find_col("Offset")
+
+    if lane_id_col is None or lat_col is None or lon_col is None or offset_col is None:
+        return {}
+
+    try:
+        lat_vals = [float(v) for v in lanes_geom_df[lat_col].astype(float).to_list()]
+        lon_vals = [float(v) for v in lanes_geom_df[lon_col].astype(float).to_list()]
+        offsets_cm = [float(v) for v in lanes_geom_df[offset_col].astype(float).to_list()]
+    except Exception:
+        return {}
+
+    lane_ids = [
+        _canonical_numeric(value)
+        for value in lanes_geom_df[lane_id_col].to_list()
+    ]
+
+    if not lane_ids or len(lane_ids) != len(offsets_cm):
+        return {}
+
+    if geo_origin is not None:
+        lat0, lon0 = geo_origin
+    else:
+        lat0 = lat_vals[0]
+        lon0 = lon_vals[0]
+
+    x_vals, y_vals = latlon_to_local_xy(lat_vals, lon_vals, lat0, lon0)
+
+    side_samples: Dict[str, List[float]] = {}
+
+    for lane_id, off_cm, px, py in zip(lane_ids, offsets_cm, x_vals, y_vals):
+        if lane_id is None:
+            continue
+        try:
+            s_val = float(off_cm) / 100.0
+        except (TypeError, ValueError):
+            continue
+        if offset_mapper is not None:
+            try:
+                s_val = float(offset_mapper(s_val))
+            except Exception:
+                continue
+
+        cx, cy, hdg = _interpolate_centerline_pose(centerline, s_val)
+        dx = px - cx
+        dy = py - cy
+        left_x = -math.sin(hdg)
+        left_y = math.cos(hdg)
+        signed = dx * left_x + dy * left_y
+        if not math.isfinite(signed):
+            continue
+        side_samples.setdefault(lane_id, []).append(signed)
+
+    side_map: Dict[str, str] = {}
+    for lane_id, values in side_samples.items():
+        if not values:
+            continue
+        avg = sum(values) / len(values)
+        if abs(avg) <= 0.05:
+            continue
+        side_map[lane_id] = "left" if avg > 0.0 else "right"
+
+    return side_map
+
+
+def _build_division_lookup(
+    lane_div_df: Optional[DataFrame],
+    line_geometry_lookup: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+    offset_mapper=None,
+) -> Dict[str, Dict[str, Any]]:
     if lane_div_df is None or len(lane_div_df) == 0:
         return {}
 
@@ -294,6 +421,9 @@ def build_lane_spec(
     *,
     line_geometry_lookup: Optional[Dict[str, List[Dict[str, Any]]]] = None,
     offset_mapper=None,
+    lanes_geometry_df: Optional[DataFrame] = None,
+    centerline: Optional[DataFrame] = None,
+    geo_origin: Optional[Tuple[float, float]] = None,
 ) -> List[Dict[str, Any]]:
     """Return metadata for each lane section used by the writer."""
 
@@ -347,6 +477,13 @@ def build_lane_spec(
 
     division_lookup = _build_division_lookup(
         lane_div_df, line_geometry_lookup=line_geometry_lookup, offset_mapper=offset_mapper
+    )
+
+    geometry_side_hint = _estimate_lane_side_from_geometry(
+        lanes_geometry_df,
+        centerline,
+        offset_mapper=offset_mapper,
+        geo_origin=geo_origin,
     )
 
     lane_no_by_base: Dict[str, Optional[int]] = {}
@@ -404,32 +541,83 @@ def build_lane_spec(
     if lane_count and len(ordered_lane_numbers) > lane_count:
         ordered_lane_numbers = ordered_lane_numbers[:lane_count]
 
-    if positive_bases and negative_bases:
-        # When the input data contains explicit lane number signs we rely on
-        # them to determine the side of the reference line.  This avoids
-        # mis-classifying sequential lane groups that belong to the same
-        # carriageway (a frequent pattern in MPUs where lane IDs change along
-        # the path but the driving direction does not).
-        left_bases = sorted(set(positive_bases), key=lambda b: base_ids.index(b))
-        right_bases = sorted(set(negative_bases), key=lambda b: base_ids.index(b))
-    else:
-        if lane_count:
-            target_left = lane_count // 2
+    def _ordered_subset(candidates: Iterable[str]) -> List[str]:
+        seen: List[str] = []
+        for base in base_ids:
+            if base in candidates and base not in seen:
+                seen.append(base)
+        return seen
+
+    hinted_left = _ordered_subset(
+        [base for base, side in geometry_side_hint.items() if side == "left"]
+    )
+    hinted_right = _ordered_subset(
+        [base for base, side in geometry_side_hint.items() if side == "right"]
+    )
+
+    remaining_bases = [
+        base
+        for base in base_ids
+        if base not in hinted_left and base not in hinted_right
+    ]
+
+    derived_left: List[str] = []
+    derived_right: List[str] = []
+
+    if remaining_bases:
+        if positive_bases and negative_bases:
+            derived_left = _ordered_subset(
+                [base for base in positive_bases if base in remaining_bases]
+            )
+            derived_right = _ordered_subset(
+                [base for base in negative_bases if base in remaining_bases]
+            )
         else:
-            target_left = len(ordered_lane_numbers) // 2
-        left_lane_numbers = set(ordered_lane_numbers[:target_left])
-        if lane_count:
-            right_limit = min(lane_count, len(ordered_lane_numbers))
+            if lane_count:
+                target_left = lane_count // 2
+            else:
+                target_left = len(ordered_lane_numbers) // 2
+            left_lane_numbers = set(ordered_lane_numbers[:target_left])
+            if lane_count:
+                right_limit = min(lane_count, len(ordered_lane_numbers))
+            else:
+                right_limit = len(ordered_lane_numbers)
+            right_lane_numbers = set(ordered_lane_numbers[target_left:right_limit])
+            derived_left = [
+                base
+                for base in remaining_bases
+                if lane_no_by_base.get(base) in left_lane_numbers
+            ]
+            derived_right = [
+                base
+                for base in remaining_bases
+                if lane_no_by_base.get(base) in right_lane_numbers
+            ]
+
+    left_bases = hinted_left + [
+        base for base in derived_left if base not in hinted_left and base not in hinted_right
+    ]
+    right_bases = hinted_right + [
+        base for base in derived_right if base not in hinted_left and base not in hinted_right
+    ]
+
+    if not hinted_left and not hinted_right:
+        if not left_bases and base_ids:
+            left_bases = base_ids[:1]
+            right_bases = [base for base in base_ids if base not in left_bases]
+        elif not right_bases and base_ids:
+            right_bases = [base for base in base_ids if base not in left_bases]
+
+    unassigned = [
+        base for base in base_ids if base not in left_bases and base not in right_bases
+    ]
+    for base in unassigned:
+        if len(left_bases) <= len(right_bases):
+            left_bases.append(base)
         else:
-            right_limit = len(ordered_lane_numbers)
-        right_lane_numbers = set(ordered_lane_numbers[target_left:right_limit])
-        left_bases = [
-            base for base in base_ids if lane_no_by_base.get(base) in left_lane_numbers
-        ]
-        right_bases = [
-            base for base in base_ids if lane_no_by_base.get(base) in right_lane_numbers
-        ]
-    if not left_bases and base_ids:
+            right_bases.append(base)
+
+    if not left_bases and not right_bases and base_ids:
         left_bases = base_ids[:1]
         right_bases = [base for base in base_ids if base not in left_bases]
 


### PR DESCRIPTION
## Summary
- derive lane side hints from the lanes_geometry dataset and use them when assigning lane bases
- plumb the additional geometry data into the lane specification builder so the conversion stays consistent

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68de22c3b7bc832781d3236e036c00e0