### PR TITLE
Fix lane side estimation for JPN CSVs

### DIFF
--- a/out/JPN/map.xodr
+++ b/out/JPN/map.xodr
@@ -880,39 +880,39 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.590" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.391" b="0" c="0" d="0"/>
             <link>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
+        </left>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.590" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
             <width sOffset="0.0" a="3.910" b="0" c="0" d="0"/>
             <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
-              <successor id="2"/>
+              <successor id="-2"/>
             </link>
           </lane>
-          <lane id="3" type="driving" level="false">
+          <lane id="-3" type="driving" level="false">
             <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
             <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
-              <successor id="3"/>
+              <successor id="-3"/>
             </link>
           </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.391" b="0" c="0" d="0"/>
-            <link>
-              <successor id="4"/>
-            </link>
-          </lane>
-        </left>
-        <right>
-          <lane id="-1" type="shoulder" level="false">
+          <lane id="-4" type="shoulder" level="false">
             <width sOffset="0.0" a="0.398" b="0" c="0" d="0"/>
             <link>
-              <successor id="-1"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -922,44 +922,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.425" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.880" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.610" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.425" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.324" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.880" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.610" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.324" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -969,44 +969,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.410" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.890" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
+        </left>
+        <right>
+          <lane id="-1" type="driving" level="false">
             <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
             <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.410" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
-        </left>
-        <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.330" b="0" c="0" d="0"/>
-            <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.890" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.330" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1016,44 +1016,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.660" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.398" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.790" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.398" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.318" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.660" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.790" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.318" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1063,44 +1063,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.447" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.800" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.610" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.447" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.252" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.800" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.610" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.252" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1110,44 +1110,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.670" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.435" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.800" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.560" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.435" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.343" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.670" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.800" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.560" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.343" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1157,44 +1157,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.690" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.535" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.780" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.480" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.535" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.369" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.690" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.780" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.480" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.369" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1204,44 +1204,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.596" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.820" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.470" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.596" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.341" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.820" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.470" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.341" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1251,44 +1251,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.660" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.573" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.790" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.490" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.573" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.394" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.660" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.790" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.490" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.394" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1298,44 +1298,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.508" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.800" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.550" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.508" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.562" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.800" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.550" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.562" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1345,44 +1345,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.640" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.547" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.750" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.600" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.547" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.518" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.640" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.750" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.600" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.518" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1392,44 +1392,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.505" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.840" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.580" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.505" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.349" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.840" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.580" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.349" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1439,44 +1439,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+          <lane id="1" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.560" b="0" c="0" d="0"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.770" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.560" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.560" b="0" c="0" d="0"/>
-            <link>
-              <predecessor id="4"/>
-              <successor id="4"/>
-            </link>
-          </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.355" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
               <successor id="-1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.770" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="-2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.560" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="-3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.355" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-4"/>
             </link>
           </lane>
         </right>
@@ -1486,44 +1486,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="driving" level="false">
-            <width sOffset="0.0" a="3.640" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="1"/>
-              <successor id="-1"/>
-            </link>
-          </lane>
-          <lane id="2" type="driving" level="false">
-            <width sOffset="0.0" a="3.820" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="-2"/>
-            </link>
-          </lane>
-          <lane id="3" type="driving" level="false">
-            <width sOffset="0.0" a="3.470" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="-3"/>
-            </link>
-          </lane>
-          <lane id="4" type="shoulder" level="false">
+          <lane id="1" type="shoulder" level="false">
             <width sOffset="0.0" a="1.621" b="0" c="0" d="0"/>
             <link>
-              <predecessor id="4"/>
-              <successor id="1"/>
+              <predecessor id="1"/>
+              <successor id="4"/>
             </link>
           </lane>
         </left>
         <right>
-          <lane id="-1" type="shoulder" level="false">
-            <width sOffset="0.0" a="0.474" b="0" c="0" d="0"/>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0.0" a="3.640" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="-1"/>
-              <successor id="-4"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="-2" type="driving" level="false">
+            <width sOffset="0.0" a="3.820" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="-3" type="driving" level="false">
+            <width sOffset="0.0" a="3.470" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="-4" type="shoulder" level="false">
+            <width sOffset="0.0" a="0.474" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="-4"/>
+              <successor id="-1"/>
             </link>
           </lane>
         </right>
@@ -1533,44 +1533,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="shoulder" level="false">
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.660" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-1"/>
+              <successor id="1"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.740" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-2"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.540" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="-3"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="4" type="shoulder" level="false">
             <width sOffset="0.0" a="1.636" b="0" c="0" d="0"/>
             <link>
-              <predecessor id="4"/>
-              <successor id="1"/>
+              <predecessor id="1"/>
+              <successor id="4"/>
             </link>
           </lane>
         </left>
         <right>
-          <lane id="-1" type="driving" level="false">
-            <width sOffset="0.0" a="3.660" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="1"/>
-              <successor id="-1"/>
-            </link>
-          </lane>
-          <lane id="-2" type="driving" level="false">
-            <width sOffset="0.0" a="3.740" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="2"/>
-              <successor id="-2"/>
-            </link>
-          </lane>
-          <lane id="-3" type="driving" level="false">
-            <width sOffset="0.0" a="3.540" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="3"/>
-              <successor id="-3"/>
-            </link>
-          </lane>
-          <lane id="-4" type="shoulder" level="false">
+          <lane id="-1" type="shoulder" level="false">
             <width sOffset="0.0" a="0.510" b="0" c="0" d="0"/>
             <link>
-              <predecessor id="-1"/>
-              <successor id="-4"/>
+              <predecessor id="-4"/>
+              <successor id="-1"/>
             </link>
           </lane>
         </right>
@@ -1580,44 +1580,44 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.431" b="0" c="0" d="0"/>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
               <predecessor id="1"/>
-              <successor id="1"/>
+              <successor id="2"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.750" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+              <successor id="3"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.620" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+              <successor id="4"/>
+            </link>
+          </lane>
+          <lane id="4" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.431" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="4"/>
+              <successor id="5"/>
             </link>
           </lane>
         </left>
         <right>
-          <lane id="-1" type="driving" level="false">
-            <width sOffset="0.0" a="3.650" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="-1"/>
-              <successor id="-2"/>
-            </link>
-          </lane>
-          <lane id="-2" type="driving" level="false">
-            <width sOffset="0.0" a="3.750" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="-2"/>
-              <successor id="-3"/>
-            </link>
-          </lane>
-          <lane id="-3" type="driving" level="false">
-            <width sOffset="0.0" a="3.620" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="-3"/>
-              <successor id="-4"/>
-            </link>
-          </lane>
-          <lane id="-4" type="shoulder" level="false">
+          <lane id="-1" type="shoulder" level="false">
             <width sOffset="0.0" a="0.517" b="0" c="0" d="0"/>
             <link>
-              <predecessor id="-4"/>
-              <successor id="-5"/>
+              <predecessor id="-1"/>
+              <successor id="-1"/>
             </link>
           </lane>
         </right>
@@ -1627,48 +1627,48 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="shoulder" level="false">
-            <width sOffset="0.0" a="1.027" b="0" c="0" d="0"/>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.600" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.150" color="standard" laneChange="none"/>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.730" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.150" color="standard" laneChange="none"/>
             <link>
               <predecessor id="1"/>
               <successor id="1"/>
             </link>
           </lane>
-        </left>
-        <right>
-          <lane id="-1" type="driving" level="false">
-            <width sOffset="0.0" a="3.600" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.150" color="standard" laneChange="none"/>
-          </lane>
-          <lane id="-2" type="driving" level="false">
-            <width sOffset="0.0" a="3.730" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="-1"/>
-              <successor id="-1"/>
-            </link>
-          </lane>
-          <lane id="-3" type="driving" level="false">
+          <lane id="3" type="driving" level="false">
             <width sOffset="0.0" a="3.780" b="0" c="0" d="0"/>
             <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
-              <predecessor id="-2"/>
-              <successor id="-2"/>
+              <predecessor id="2"/>
+              <successor id="2"/>
             </link>
           </lane>
-          <lane id="-4" type="driving" level="false">
+          <lane id="4" type="driving" level="false">
             <width sOffset="0.0" a="3.830" b="0" c="0" d="0"/>
             <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
             <link>
-              <predecessor id="-3"/>
-              <successor id="-3"/>
+              <predecessor id="3"/>
+              <successor id="3"/>
             </link>
           </lane>
-          <lane id="-5" type="shoulder" level="false">
+          <lane id="5" type="shoulder" level="false">
+            <width sOffset="0.0" a="1.027" b="0" c="0" d="0"/>
+            <link>
+              <predecessor id="4"/>
+              <successor id="4"/>
+            </link>
+          </lane>
+        </left>
+        <right>
+          <lane id="-1" type="shoulder" level="false">
             <width sOffset="0.0" a="0.446" b="0" c="0" d="0"/>
             <link>
-              <predecessor id="-4"/>
-              <successor id="-4"/>
+              <predecessor id="-1"/>
+              <successor id="-1"/>
             </link>
           </lane>
         </right>
@@ -1678,39 +1678,39 @@
           <lane id="0" type="none" level="false"/>
         </center>
         <left>
-          <lane id="1" type="shoulder" level="false">
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="2"/>
+            </link>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0.0" a="3.760" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="3"/>
+            </link>
+          </lane>
+          <lane id="3" type="driving" level="false">
+            <width sOffset="0.0" a="3.590" b="0" c="0" d="0"/>
+            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
+            <link>
+              <predecessor id="4"/>
+            </link>
+          </lane>
+          <lane id="4" type="shoulder" level="false">
             <width sOffset="0.0" a="0.155" b="0" c="0" d="0"/>
             <link>
-              <predecessor id="1"/>
+              <predecessor id="5"/>
             </link>
           </lane>
         </left>
         <right>
-          <lane id="-1" type="driving" level="false">
-            <width sOffset="0.0" a="3.630" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="-2"/>
-            </link>
-          </lane>
-          <lane id="-2" type="driving" level="false">
-            <width sOffset="0.0" a="3.760" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="-3"/>
-            </link>
-          </lane>
-          <lane id="-3" type="driving" level="false">
-            <width sOffset="0.0" a="3.590" b="0" c="0" d="0"/>
-            <roadMark sOffset="0.0" type="solid" weight="standard" width="0.200" color="standard" laneChange="none"/>
-            <link>
-              <predecessor id="-4"/>
-            </link>
-          </lane>
-          <lane id="-4" type="shoulder" level="false">
+          <lane id="-1" type="shoulder" level="false">
             <width sOffset="0.0" a="0.879" b="0" c="0" d="0"/>
             <link>
-              <predecessor id="-5"/>
+              <predecessor id="-1"/>
             </link>
           </lane>
         </right>

--- a/out/JPN/report.json
+++ b/out/JPN/report.json
@@ -19,7 +19,7 @@
   "road_length_m": 1370.8832848617744,
   "xodr_file": {
     "path": "/workspace/opendrive/out/JPN/map.xodr",
-    "size_bytes": 79864,
+    "size_bytes": 79953,
     "line_count": 1720
   }
 }


### PR DESCRIPTION
## Summary
- rebase lane geometry offsets before estimating lane sides so values map onto the centreline correctly
- regenerate the bundled JPN OpenDRIVE artefacts after the fix

## Testing
- pytest -q
- python pythonProject/main.py --format JPN

------
https://chatgpt.com/codex/tasks/task_e_68de6b06730483279550b218351c076a