### PR TITLE
Fix JPN height outliers causing lane artefacts

### DIFF
--- a/csv2xodr/line_geometry.py
+++ b/csv2xodr/line_geometry.py
@@ -104,9 +104,16 @@ def build_line_geometry_lookup(
         if lat_val is None or lon_val is None:
             continue
 
-        z_val = _to_float(row[z_col]) if z_col else 0.0
+        z_val = _to_float(row[z_col]) if z_col else None
+        if z_val is not None:
+            if not math.isfinite(z_val) or abs(z_val) >= 1e4:
+                z_val = None
         if z_val is None:
-            z_val = 0.0
+            existing = entry.get("z", []) or []
+            if existing:
+                z_val = existing[-1]
+            else:
+                z_val = 0.0
 
         off_cm_raw = None
         if offset_col is not None:

--- a/csv2xodr/normalize/core.py
+++ b/csv2xodr/normalize/core.py
@@ -566,6 +566,13 @@ def build_elevation_profile(
         if not math.isfinite(height):
             continue
 
+        if abs(height) >= 1e4:
+            # Sentinel-style placeholders in some datasets use extremely large
+            # values (for example ``83886.07``) to signal that the real
+            # elevation measurement is unavailable.  Treat them as missing data
+            # instead of letting them skew the typical height statistics.
+            continue
+
         grouped.setdefault(offset_cm, []).append(height)
         all_heights.append(height)
 
@@ -590,9 +597,6 @@ def build_elevation_profile(
         filtered: List[float] = []
         for value in heights:
             if not math.isfinite(value):
-                continue
-
-            if abs(value) >= 1e6:
                 continue
 
             if typical_height is not None:

--- a/tests/test_line_geometry.py
+++ b/tests/test_line_geometry.py
@@ -160,6 +160,42 @@ def test_build_line_geometry_lookup_keeps_mixed_retransmissions():
     assert lookup["10"][0]["s"][0] == pytest.approx(0.0)
 
 
+def test_build_line_geometry_lookup_filters_height_outliers():
+    df = DataFrame(
+        [
+            {
+                "ライン型地物ID": "50",
+                "Offset[cm]": "0",
+                "緯度[deg]": "35.0",
+                "経度[deg]": "139.0",
+                "高さ[m]": "55.0",
+                "ログ時刻": "base",
+                "Type": "1",
+                "Is Retransmission": "false",
+            },
+            {
+                "ライン型地物ID": "50",
+                "Offset[cm]": "100",
+                "緯度[deg]": "35.00001",
+                "経度[deg]": "139.00001",
+                "高さ[m]": "83886.07",
+                "ログ時刻": "base",
+                "Type": "1",
+                "Is Retransmission": "false",
+            },
+        ]
+    )
+
+    lookup = build_line_geometry_lookup(
+        df, offset_mapper=lambda value: value, lat0=35.0, lon0=139.0
+    )
+
+    assert "50" in lookup
+    geom = lookup["50"][0]
+    assert geom["z"][0] == pytest.approx(55.0)
+    assert geom["z"][1] == pytest.approx(55.0), "outlier heights should be clamped"
+
+
 def test_build_line_geometry_lookup_splits_when_offset_resets():
     df = DataFrame(
         [


### PR DESCRIPTION
## Summary
- ignore sentinel height readings when building JPN elevation profiles
- clamp lane geometry heights so invalid samples reuse the last valid value
- add regression test covering the filtered outlier behaviour

## Testing
- pytest tests/test_line_geometry.py tests/test_elevation_profile.py

------
https://chatgpt.com/codex/tasks/task_e_68de9bb6fbcc83279d709bcf68b2db06