### PR TITLE
Fix lane geometry offset rebasing for JPN datasets

### DIFF
--- a/csv2xodr/line_geometry.py
+++ b/csv2xodr/line_geometry.py
@@ -268,13 +268,26 @@ def build_line_geometry_lookup(
         last_s: Optional[float] = None
         reset_threshold = 1e-4  # tolerate sub-millimetre jitter while catching real resets
 
+        entry_base_offset: Optional[float] = None
+        for raw in offsets_raw:
+            try:
+                value = float(raw)
+            except (TypeError, ValueError):
+                continue
+            if not math.isfinite(value):
+                continue
+            if entry_base_offset is None or value < entry_base_offset:
+                entry_base_offset = value
+
         for raw_offset, x_val, y_val, z_val in zip(offsets_raw, x_vals, y_vals, z_vals):
             try:
                 offset_m = float(raw_offset)
             except (TypeError, ValueError):
                 continue
 
-            if global_base_offset is not None and math.isfinite(offset_m):
+            if entry_base_offset is not None and math.isfinite(entry_base_offset):
+                offset_m -= entry_base_offset
+            elif global_base_offset is not None and math.isfinite(global_base_offset):
                 offset_m -= global_base_offset
 
             if offset_mapper is not None:


### PR DESCRIPTION
## Summary
- rebase each lane line's longitudinal offsets before calling the centerline mapper so absolute centimetre origins no longer collapse the polylines to the road end
- keep the previous global fallback while preferring per-line minima to tolerate mixed-offset CSV exports without producing broken white-line geometry

## Testing
- python pythonProject/main.py --all

------
https://chatgpt.com/codex/tasks/task_e_68dea59125a88327bdd73109d8c52b91