### PR TITLE
Fix JPN lane orientation and preserve lane line continuity

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -673,6 +673,17 @@ def build_lane_spec(
     base_ids = sorted(lane_groups.keys(), key=_base_sort_key)
     lanes_per_base = {base: len(lane_groups[base]) for base in base_ids}
 
+    for base_id in base_ids:
+        lane_number = lane_no_by_base.get(base_id)
+        if lane_number is None or lane_number == 0:
+            continue
+        expected_side = "left" if lane_number > 0 else "right"
+        current = geometry_side_hint.get(base_id)
+        if current is None:
+            geometry_side_hint[base_id] = expected_side
+        elif current != expected_side:
+            geometry_side_hint[base_id] = expected_side
+
     def _bases_with_sign(sign: int) -> List[str]:
         selected: List[str] = []
         for base in base_ids:

--- a/csv2xodr/line_geometry.py
+++ b/csv2xodr/line_geometry.py
@@ -286,7 +286,14 @@ def build_line_geometry_lookup(
                 continue
 
             if entry_base_offset is not None and math.isfinite(entry_base_offset):
-                offset_m -= entry_base_offset
+                if (
+                    global_base_offset is not None
+                    and math.isfinite(global_base_offset)
+                    and entry_base_offset > global_base_offset + 1e-6
+                ):
+                    offset_m -= global_base_offset
+                else:
+                    offset_m -= entry_base_offset
             elif global_base_offset is not None and math.isfinite(global_base_offset):
                 offset_m -= global_base_offset
 


### PR DESCRIPTION
## Summary
- ensure lane numbering hints override ambiguous geometry when assigning lane sides so Japanese datasets keep lanes on both sides of the reference line
- refine line geometry offset normalisation so sequential segments keep their absolute position when the source CSV does not reset offsets

## Testing
- python pythonProject/main.py --all
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ded9d464f4832793085c7a41a12897