### PR TITLE
Handle positive-only lane inference without forced split

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -811,26 +811,51 @@ def build_lane_spec(
                 [base for base in negative_bases if base in remaining_bases]
             )
         else:
-            if lane_count:
-                target_left = lane_count // 2
+            if not negative_bases and not hinted_right:
+                preferred_side: Optional[str] = None
+
+                for side in geometry_side_hint.values():
+                    if side in {"left", "right"}:
+                        preferred_side = side
+                        break
+
+                if preferred_side is None and isinstance(defaults, dict):
+                    raw_default = defaults.get("default_lane_side")
+                    if isinstance(raw_default, str):
+                        lowered = raw_default.strip().lower()
+                        if lowered in {"left", "right"}:
+                            preferred_side = "left" if lowered == "left" else "right"
+
+                if preferred_side is None:
+                    preferred_side = "left"
+
+                if preferred_side == "left":
+                    derived_left = list(remaining_bases)
+                    derived_right = []
+                else:
+                    derived_right = list(remaining_bases)
+                    derived_left = []
             else:
-                target_left = len(ordered_lane_numbers) // 2
-            left_lane_numbers = set(ordered_lane_numbers[:target_left])
-            if lane_count:
-                right_limit = min(lane_count, len(ordered_lane_numbers))
-            else:
-                right_limit = len(ordered_lane_numbers)
-            right_lane_numbers = set(ordered_lane_numbers[target_left:right_limit])
-            derived_left = [
-                base
-                for base in remaining_bases
-                if lane_no_by_base.get(base) in left_lane_numbers
-            ]
-            derived_right = [
-                base
-                for base in remaining_bases
-                if lane_no_by_base.get(base) in right_lane_numbers
-            ]
+                if lane_count:
+                    target_left = lane_count // 2
+                else:
+                    target_left = len(ordered_lane_numbers) // 2
+                left_lane_numbers = set(ordered_lane_numbers[:target_left])
+                if lane_count:
+                    right_limit = min(lane_count, len(ordered_lane_numbers))
+                else:
+                    right_limit = len(ordered_lane_numbers)
+                right_lane_numbers = set(ordered_lane_numbers[target_left:right_limit])
+                derived_left = [
+                    base
+                    for base in remaining_bases
+                    if lane_no_by_base.get(base) in left_lane_numbers
+                ]
+                derived_right = [
+                    base
+                    for base in remaining_bases
+                    if lane_no_by_base.get(base) in right_lane_numbers
+                ]
 
     left_bases = hinted_left + [
         base for base in derived_left if base not in hinted_left and base not in hinted_right

--- a/tests/test_lane_spec_geometry.py
+++ b/tests/test_lane_spec_geometry.py
@@ -211,3 +211,65 @@ def test_strong_geometry_hint_overrides_lane_numbers():
 
     assert not specs[0]["left"], "strong right-side geometry should prevent left assignment"
     assert len(specs[0]["right"]) == 1
+
+
+def test_positive_lanes_stay_on_single_side():
+    sections = [{"s0": 0.0, "s1": 10.0}]
+
+    lane_topology = {
+        "lane_count": 3,
+        "groups": {
+            "A": ["A:1"],
+            "B": ["B:1"],
+            "C": ["C:1"],
+        },
+        "lanes": {
+            "A:1": {
+                "base_id": "A",
+                "lane_no": 1,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "B:1": {
+                "base_id": "B",
+                "lane_no": 2,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "C:1": {
+                "base_id": "C",
+                "lane_no": 3,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+        },
+    }
+
+    specs = build_lane_spec(sections, lane_topology, defaults={}, lane_div_df=None)
+
+    assert specs[0]["right"] == [], "positive-only lanes should not be inferred as right-side lanes"
+    assert [lane["uid"] for lane in specs[0]["left"]] == ["A:1", "B:1", "C:1"]


### PR DESCRIPTION
## Summary
- stop splitting remaining lane bases when only positive lane numbers are present and no right hints exist
- respect geometry hints and configuration when selecting the default side
- cover the regression with a unit test for positive-only lane topologies

## Testing
- pytest tests/test_lane_spec_geometry.py::test_positive_lanes_stay_on_single_side

------
https://chatgpt.com/codex/tasks/task_e_68deefac6b0483278f4bb81f726ccf5f