### PR TITLE
Fix lane side fallback for positive-only topologies

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -846,11 +846,16 @@ def build_lane_spec(
     ]
 
     if not hinted_left and not hinted_right:
-        if not left_bases and base_ids:
-            left_bases = base_ids[:1]
-            right_bases = [base for base in base_ids if base not in left_bases]
-        elif not right_bases and base_ids:
-            right_bases = [base for base in base_ids if base not in left_bases]
+        has_right_evidence = bool(negative_bases or hinted_right or derived_right)
+        if not has_right_evidence:
+            left_bases = list(base_ids)
+            right_bases = []
+        else:
+            if not left_bases and base_ids:
+                left_bases = base_ids[:1]
+                right_bases = [base for base in base_ids if base not in left_bases]
+            elif not right_bases and base_ids:
+                right_bases = [base for base in base_ids if base not in left_bases]
 
     left_base_set = set(left_bases)
     right_base_set = set(right_bases)

--- a/tests/test_lane_spec_assignment.py
+++ b/tests/test_lane_spec_assignment.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from csv2xodr.lane_spec import build_lane_spec
+from csv2xodr.simpletable import DataFrame
+from csv2xodr.topology.core import build_lane_topology
+
+
+def test_positive_lanes_remain_on_left_without_right_hints():
+    rows = []
+    for lane_no in (1, 2, 3):
+        rows.append(
+            {
+                "Offset[cm]": "0",
+                "End Offset[cm]": "100",
+                "レーンID": f"G{lane_no}",
+                "レーン番号": str(lane_no),
+                "Lane Width[m]": "3.5",
+            }
+        )
+
+    topo = build_lane_topology(DataFrame(rows))
+    sections = [{"s0": 0.0, "s1": 10.0}]
+
+    specs = build_lane_spec(sections, topo, defaults={}, lane_div_df=DataFrame([]))
+
+    left_ids = [lane["id"] for lane in specs[0]["left"]]
+    right_ids = [lane["id"] for lane in specs[0]["right"]]
+
+    assert len(left_ids) == 3
+    assert not right_ids
+    assert all(lane_id > 0 for lane_id in left_ids)


### PR DESCRIPTION
## Summary
- keep all base lanes on the same side when no right-hand evidence is available during fallback assignment
- add a regression test ensuring positive-only lane topologies remain entirely on the left side

## Testing
- pytest tests/test_lane_spec_assignment.py

------
https://chatgpt.com/codex/tasks/task_e_68def296a42c8327b0d55383f66500c4