### PR TITLE
Avoid splitting positive-only lanes onto the right side

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -793,29 +793,11 @@ def build_lane_spec(
             )
         else:
             if not negative_bases and not hinted_right:
-                preferred_side: Optional[str] = None
-
-                for side in geometry_side_hint.values():
-                    if side in {"left", "right"}:
-                        preferred_side = side
-                        break
-
-                if preferred_side is None and isinstance(defaults, dict):
-                    raw_default = defaults.get("default_lane_side")
-                    if isinstance(raw_default, str):
-                        lowered = raw_default.strip().lower()
-                        if lowered in {"left", "right"}:
-                            preferred_side = "left" if lowered == "left" else "right"
-
-                if preferred_side is None:
-                    preferred_side = "left"
-
-                if preferred_side == "left":
-                    derived_left = list(remaining_bases)
-                    derived_right = []
-                else:
-                    derived_right = list(remaining_bases)
-                    derived_left = []
+                derived_left = list(remaining_bases)
+                derived_right = []
+            elif not positive_bases and not hinted_left:
+                derived_right = list(remaining_bases)
+                derived_left = []
             else:
                 if lane_count:
                     target_left = lane_count // 2
@@ -848,7 +830,7 @@ def build_lane_spec(
     if not hinted_left and not hinted_right:
         has_right_evidence = bool(negative_bases or hinted_right or derived_right)
         if not has_right_evidence:
-            left_bases = list(base_ids)
+            left_bases = list(left_bases or base_ids)
             right_bases = []
         else:
             if not left_bases and base_ids:

--- a/tests/test_lane_spec_assignment.py
+++ b/tests/test_lane_spec_assignment.py
@@ -35,3 +35,35 @@ def test_positive_lanes_remain_on_left_without_right_hints():
     assert len(left_ids) == 3
     assert not right_ids
     assert all(lane_id > 0 for lane_id in left_ids)
+
+
+def test_positive_lanes_ignore_lane_count_based_split():
+    rows = []
+    for lane_no in (1, 2, 3):
+        rows.append(
+            {
+                "Offset[cm]": "0",
+                "End Offset[cm]": "100",
+                "レーンID": f"G{lane_no}",
+                "レーン番号": str(lane_no),
+                "Lane Width[m]": "3.5",
+                "Lane Count": "6",
+            }
+        )
+
+    topo = build_lane_topology(DataFrame(rows))
+    sections = [{"s0": 0.0, "s1": 10.0}]
+
+    specs = build_lane_spec(
+        sections,
+        topo,
+        defaults={"default_lane_side": "right"},
+        lane_div_df=DataFrame([]),
+    )
+
+    left_ids = [lane["id"] for lane in specs[0]["left"]]
+    right_ids = [lane["id"] for lane in specs[0]["right"]]
+
+    assert len(left_ids) == 3
+    assert not right_ids
+    assert all(lane_id > 0 for lane_id in left_ids)


### PR DESCRIPTION
## Summary
- stop forcing positive-only lane groups back onto the right when there are no right-side hints
- refine remaining-lane distribution fallback logic to preserve derived assignments without right evidence
- add a regression test covering positive-only lanes with a lane count hint

## Testing
- pytest tests/test_lane_spec_assignment.py

------
https://chatgpt.com/codex/tasks/task_e_68def5da151083278f24d5e345e45f64