### PR TITLE
Avoid splitting positive lanes without right evidence

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -747,10 +747,9 @@ def build_lane_spec(
         ordered_lane_numbers = ordered_lane_numbers[:lane_count]
 
     has_geometry_right_hint = any(side == "right" for side in geometry_side_hint.values())
+    no_right_evidence = not negative_bases and not has_geometry_right_hint
 
-    only_positive_without_right_evidence = (
-        not has_geometry_right_hint and not negative_bases and bool(positive_bases)
-    )
+    only_positive_without_right_evidence = no_right_evidence and bool(positive_bases)
 
     if only_positive_without_right_evidence:
         # 没有任何右侧提示且全部车道编号为正，说明输入数据没有明确区分两侧。
@@ -786,7 +785,7 @@ def build_lane_spec(
     derived_right: List[str] = []
 
     if remaining_bases:
-        if not negative_bases and not hinted_right:
+        if no_right_evidence and not hinted_right:
             derived_left = list(remaining_bases)
             derived_right = []
         elif positive_bases and negative_bases:
@@ -797,7 +796,9 @@ def build_lane_spec(
                 [base for base in negative_bases if base in remaining_bases]
             )
         else:
-            has_right_evidence = bool(negative_bases or hinted_right)
+            has_right_evidence = bool(
+                negative_bases or hinted_right or has_geometry_right_hint
+            )
             has_left_evidence = bool(positive_bases or hinted_left)
 
             if not has_right_evidence:
@@ -845,7 +846,7 @@ def build_lane_spec(
     ]
 
     force_all_left = bool(
-        not negative_bases and not hinted_right and not derived_right
+        no_right_evidence and not hinted_right and not derived_right
     )
     if force_all_left:
         left_bases = [base for base in base_ids]

--- a/tests/test_lane_spec_assignment.py
+++ b/tests/test_lane_spec_assignment.py
@@ -158,3 +158,34 @@ def test_positive_lanes_without_right_evidence_fill_left_side():
         assert len(left_ids) == 5
         assert not right_ids
         assert all(lane_id > 0 for lane_id in left_ids)
+
+
+def test_lane_spec_keeps_only_positive_lanes_on_left():
+    rows = []
+    for lane_no in (1, 2):
+        rows.append(
+            {
+                "Offset[cm]": "0",
+                "End Offset[cm]": "80",
+                "レーンID": f"G{lane_no}",
+                "レーン番号": str(lane_no),
+                "Lane Width[m]": "3.0",
+                "Lane Count": "6",
+            }
+        )
+
+    topo = build_lane_topology(DataFrame(rows))
+    sections = [{"s0": 0.0, "s1": 8.0}]
+
+    specs = build_lane_spec(
+        sections,
+        topo,
+        defaults={"default_lane_side": "right"},
+        lane_div_df=DataFrame([]),
+    )
+
+    left_ids = [lane["id"] for lane in specs[0]["left"]]
+    right_ids = [lane["id"] for lane in specs[0]["right"]]
+
+    assert left_ids == [1, 2]
+    assert not right_ids


### PR DESCRIPTION
## Summary
- update the lane assignment logic to skip lane_count-based splits when no right-side evidence exists
- add a regression test ensuring only positive lanes stay on the left side

## Testing
- pytest tests/test_lane_spec_assignment.py

------
https://chatgpt.com/codex/tasks/task_e_68defd8aec1483278f4e1bfcac02107b