### PR TITLE
Prevent splitting positive lanes without right clues

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -826,26 +826,38 @@ def build_lane_spec(
                     derived_left = list(remaining_bases)
                     derived_right = []
             else:
-                if lane_count:
-                    target_left = lane_count // 2
+                if (
+                    not negative_bases
+                    and not hinted_right
+                    and not derived_right
+                ):
+                    derived_left = list(remaining_bases)
+                    derived_right = []
                 else:
-                    target_left = len(ordered_lane_numbers) // 2
-                left_lane_numbers = set(ordered_lane_numbers[:target_left])
-                if lane_count:
-                    right_limit = min(lane_count, len(ordered_lane_numbers))
-                else:
-                    right_limit = len(ordered_lane_numbers)
-                right_lane_numbers = set(ordered_lane_numbers[target_left:right_limit])
-                derived_left = [
-                    base
-                    for base in remaining_bases
-                    if lane_no_by_base.get(base) in left_lane_numbers
-                ]
-                derived_right = [
-                    base
-                    for base in remaining_bases
-                    if lane_no_by_base.get(base) in right_lane_numbers
-                ]
+                    if lane_count:
+                        target_left = lane_count // 2
+                    else:
+                        target_left = len(ordered_lane_numbers) // 2
+                    left_lane_numbers = set(ordered_lane_numbers[:target_left])
+                    if lane_count:
+                        right_limit = min(
+                            lane_count, len(ordered_lane_numbers)
+                        )
+                    else:
+                        right_limit = len(ordered_lane_numbers)
+                    right_lane_numbers = set(
+                        ordered_lane_numbers[target_left:right_limit]
+                    )
+                    derived_left = [
+                        base
+                        for base in remaining_bases
+                        if lane_no_by_base.get(base) in left_lane_numbers
+                    ]
+                    derived_right = [
+                        base
+                        for base in remaining_bases
+                        if lane_no_by_base.get(base) in right_lane_numbers
+                    ]
 
     if (
         remaining_bases
@@ -870,6 +882,9 @@ def build_lane_spec(
     force_all_default_side = bool(
         no_right_evidence and not hinted_right and not derived_right
     )
+    no_right_side_assignments = (
+        not negative_bases and not hinted_right and not derived_right
+    )
 
     if force_all_default_side:
         if default_lane_side_is_right:
@@ -887,6 +902,7 @@ def build_lane_spec(
             force_all_default_side
             or not has_right_evidence
             or only_positive_without_right_evidence
+            or no_right_side_assignments
         ):
             if default_lane_side_is_right:
                 left_bases = []

--- a/tests/test_lane_spec_links.py
+++ b/tests/test_lane_spec_links.py
@@ -204,6 +204,56 @@ def test_lane_spec_keeps_positive_lane_numbers_on_same_side():
     assert specs[0]["right"] == []
 
 
+def test_lane_spec_does_not_split_positive_lanes_with_lane_count():
+    sections = [{"s0": 0.0, "s1": 10.0}]
+
+    lane_topology = {
+        "lane_count": 2,
+        "groups": {
+            "A": ["A:1"],
+            "B": ["B:2"],
+        },
+        "lanes": {
+            "A:1": {
+                "base_id": "A",
+                "lane_no": 1,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "B:2": {
+                "base_id": "B",
+                "lane_no": 2,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+        },
+    }
+
+    specs = build_lane_spec(sections, lane_topology, defaults={}, lane_div_df=None)
+
+    assert len(specs) == 1
+    left_ids = [lane["id"] for lane in specs[0]["left"]]
+
+    assert left_ids == [1, 2]
+    assert specs[0]["right"] == []
+
+
 def test_write_xodr_ignores_zero_length_centerline_segments(tmp_path):
     centerline = _SimpleCenterline({
         "s": [0.0, 5.0, 5.0, 10.0],


### PR DESCRIPTION
## Summary
- avoid deriving right-side lanes when lane_count is provided but no right-side hints exist
- update the fallback assignment logic to respect the default side when only positive lanes are present
- add a regression test ensuring positive-only lane configurations keep every lane on the same side

## Testing
- pytest tests/test_lane_spec_links.py

------
https://chatgpt.com/codex/tasks/task_e_68df02c461908327b1d8a278e12e30c5