### PR TITLE
Prevent lane_count splitting for positive-only lane topologies

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -791,6 +791,9 @@ def build_lane_spec(
     derived_left: List[str] = []
     derived_right: List[str] = []
 
+    def _single_side_positive_only() -> bool:
+        return not negative_bases and not hinted_right and not derived_right
+
     if remaining_bases:
         if no_right_evidence and not hinted_right:
             derived_left = list(remaining_bases)
@@ -814,11 +817,7 @@ def build_lane_spec(
             elif not has_left_evidence:
                 derived_right = list(remaining_bases)
                 derived_left = []
-            elif (
-                not negative_bases
-                and not hinted_right
-                and not derived_right
-            ):
+            elif _single_side_positive_only():
                 if default_lane_side_is_right:
                     derived_left = []
                     derived_right = list(remaining_bases)
@@ -826,20 +825,16 @@ def build_lane_spec(
                     derived_left = list(remaining_bases)
                     derived_right = []
             else:
-                if (
-                    not negative_bases
-                    and not hinted_right
-                    and not derived_right
-                ):
+                if _single_side_positive_only():
                     derived_left = list(remaining_bases)
                     derived_right = []
                 else:
-                    if lane_count:
+                    if lane_count and not _single_side_positive_only():
                         target_left = lane_count // 2
                     else:
                         target_left = len(ordered_lane_numbers) // 2
                     left_lane_numbers = set(ordered_lane_numbers[:target_left])
-                    if lane_count:
+                    if lane_count and not _single_side_positive_only():
                         right_limit = min(
                             lane_count, len(ordered_lane_numbers)
                         )
@@ -859,12 +854,7 @@ def build_lane_spec(
                         if lane_no_by_base.get(base) in right_lane_numbers
                     ]
 
-    if (
-        remaining_bases
-        and not negative_bases
-        and not hinted_right
-        and not derived_right
-    ):
+    if remaining_bases and _single_side_positive_only():
         if default_lane_side_is_right:
             derived_left = []
             derived_right = list(remaining_bases)
@@ -923,7 +913,7 @@ def build_lane_spec(
     unassigned = [
         base for base in base_ids if base not in left_base_set and base not in right_base_set
     ]
-    if not force_all_default_side:
+    if not force_all_default_side and not _single_side_positive_only():
         for base in unassigned:
             neighbour_side: Optional[str] = None
             for uid in lane_groups.get(base, []):

--- a/tests/test_lane_spec_links.py
+++ b/tests/test_lane_spec_links.py
@@ -254,6 +254,71 @@ def test_lane_spec_does_not_split_positive_lanes_with_lane_count():
     assert specs[0]["right"] == []
 
 
+def test_lane_spec_handles_jpn_positive_only_topology():
+    sections = [{"s0": 0.0, "s1": 30.0}]
+
+    lane_topology = {
+        "lane_count": 6,
+        "groups": {
+            "5.13001000000048e+18": ["lane::1"],
+            "5.13001000000049e+18": ["lane::2"],
+            "5.13001000000050e+18": ["lane::3"],
+        },
+        "lanes": {
+            "lane::1": {
+                "base_id": "5.13001000000048e+18",
+                "lane_no": 1,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 30.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "lane::2": {
+                "base_id": "5.13001000000049e+18",
+                "lane_no": 2,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 30.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "lane::3": {
+                "base_id": "5.13001000000050e+18",
+                "lane_no": 3,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 30.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+        },
+    }
+
+    specs = build_lane_spec(sections, lane_topology, defaults={}, lane_div_df=None)
+
+    assert len(specs) == 1
+    left_ids = [lane["id"] for lane in specs[0]["left"]]
+
+    assert left_ids == [1, 2, 3]
+    assert specs[0]["right"] == []
+
+
 def test_write_xodr_ignores_zero_length_centerline_segments(tmp_path):
     centerline = _SimpleCenterline({
         "s": [0.0, 5.0, 5.0, 10.0],


### PR DESCRIPTION
## Summary
- guard the lane_count-based split so positive-only lane groups remain on a single side
- keep unassigned and fallback handling aligned with the positive-only guard
- add a regression test that mirrors the JPN topology with only positive lane numbers

## Testing
- pytest tests/test_lane_spec_links.py tests/test_lane_spec_assignment.py

------
https://chatgpt.com/codex/tasks/task_e_68df05ff9d9083278bec1943e825e797