### PR TITLE
Update lane spec positive-only lane tests

### DIFF
--- a/tests/test_lane_spec_links.py
+++ b/tests/test_lane_spec_links.py
@@ -160,7 +160,7 @@ def test_lane_spec_flags_and_writer_links(tmp_path):
     assert last_right_link.find("successor") is None
 
 
-def test_lane_spec_keeps_positive_lane_numbers_on_same_side():
+def test_lane_spec_uses_lane_count_when_only_positive_lane_numbers():
     sections = [{"s0": 0.0, "s1": 10.0}]
 
     lane_topology = {
@@ -198,10 +198,86 @@ def test_lane_spec_keeps_positive_lane_numbers_on_same_side():
     specs = build_lane_spec(sections, lane_topology, defaults={}, lane_div_df=None)
 
     assert len(specs) == 1
-    left_ids = [lane["id"] for lane in specs[0]["left"]]
-
-    assert left_ids == [1, 2, 3, 4]
+    assert [lane["id"] for lane in specs[0]["left"]] == [1, 2, 3, 4]
     assert specs[0]["right"] == []
+
+
+def test_lane_spec_balances_positive_and_negative_lane_numbers():
+    sections = [{"s0": 0.0, "s1": 10.0}]
+
+    lane_topology = {
+        "lane_count": 4,
+        "groups": {
+            "A": ["A:1"],
+            "B": ["B:2"],
+            "C": ["C:-1"],
+            "D": ["D:-2"],
+        },
+        "lanes": {
+            "A:1": {
+                "base_id": "A",
+                "lane_no": 1,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "B:2": {
+                "base_id": "B",
+                "lane_no": 2,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "C:-1": {
+                "base_id": "C",
+                "lane_no": -1,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "D:-2": {
+                "base_id": "D",
+                "lane_no": -2,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+        },
+    }
+
+    specs = build_lane_spec(sections, lane_topology, defaults={}, lane_div_df=None)
+
+    assert len(specs) == 1
+    assert [lane["id"] for lane in specs[0]["left"]] == [1, 2]
+    assert [lane["id"] for lane in specs[0]["right"]] == [-1, -2]
 
 
 def test_lane_spec_does_not_split_positive_lanes_with_lane_count():


### PR DESCRIPTION
## Summary
- update the positive-only lane-count test to ensure all lanes stay on the same side when no right-hand clues exist
- add a mixed positive/negative lane-number test to confirm bidirectional lane assignments continue to work

## Testing
- pytest tests/test_lane_spec_links.py -k lane_spec_uses_lane_count_when_only_positive_lane_numbers
- pytest tests/test_lane_spec_links.py -k balances_positive_and_negative_lane_numbers

------
https://chatgpt.com/codex/tasks/task_e_68df15801f8483279b85e57026d1da9d