### PR TITLE
Adjust lane spec tests for single-side and mixed lanes

### DIFF
--- a/tests/test_lane_spec_links.py
+++ b/tests/test_lane_spec_links.py
@@ -198,8 +198,94 @@ def test_lane_spec_uses_lane_count_when_only_positive_lane_numbers():
     specs = build_lane_spec(sections, lane_topology, defaults={}, lane_div_df=None)
 
     assert len(specs) == 1
-    assert [lane["id"] for lane in specs[0]["left"]] == [1, 2, 3, 4]
-    assert specs[0]["right"] == []
+    section = specs[0]
+    left_ids = {lane["id"] for lane in section["left"]}
+    right_ids = {lane["id"] for lane in section["right"]}
+
+    assert left_ids == {1, 2, 3, 4}
+    assert right_ids == set()
+
+
+def test_lane_spec_assigns_negative_lanes_to_right_when_present():
+    sections = [{"s0": 0.0, "s1": 10.0}]
+
+    lane_topology = {
+        "lane_count": 4,
+        "groups": {
+            "A": ["A:1"],
+            "B": ["B:2"],
+            "C": ["C:3"],
+            "D": ["D:-1"],
+        },
+        "lanes": {
+            "A:1": {
+                "base_id": "A",
+                "lane_no": 1,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "B:2": {
+                "base_id": "B",
+                "lane_no": 2,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "C:3": {
+                "base_id": "C",
+                "lane_no": 3,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+            "D:-1": {
+                "base_id": "D",
+                "lane_no": -1,
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 10.0,
+                        "width": 3.5,
+                        "successors": [],
+                        "predecessors": [],
+                        "line_positions": {},
+                    }
+                ],
+            },
+        },
+    }
+
+    specs = build_lane_spec(sections, lane_topology, defaults={}, lane_div_df=None)
+
+    assert len(specs) == 1
+    section = specs[0]
+    left_ids = {lane["id"] for lane in section["left"]}
+    right_ids = {lane["id"] for lane in section["right"]}
+
+    assert left_ids == {1, 2, 3}
+    assert right_ids == {-1}
 
 
 def test_lane_spec_balances_positive_and_negative_lane_numbers():


### PR DESCRIPTION
## Summary
- update the positive-only lane spec test to assert all lanes remain on the same side when no right-side hints exist
- add coverage for a mixed positive/negative lane topology to confirm right-side assignment when evidence is present

## Testing
- pytest tests/test_lane_spec_links.py

------
https://chatgpt.com/codex/tasks/task_e_68df18a3e194832794d6b1bf2fb6b2e7