### PR TITLE
Fix lane assignment when no right evidence

### DIFF
--- a/tests/test_lane_spec_links.py
+++ b/tests/test_lane_spec_links.py
@@ -367,7 +367,7 @@ def test_lane_spec_balances_positive_and_negative_lane_numbers():
     assert [lane["id"] for lane in specs[0]["right"]] == [-1, -2]
 
 
-def test_lane_spec_does_not_split_positive_lanes_with_lane_count():
+def test_lane_spec_uses_lane_count_when_only_positive_lane_numbers():
     sections = [{"s0": 0.0, "s1": 10.0}]
 
     lane_topology = {


### PR DESCRIPTION
## Summary
- stop splitting lanes by lane_count when no right-side evidence is present and keep all bases on a single side
- adjust the fallback assignment logic in build_lane_spec to avoid moving bases to the right without supporting hints
- update the lane-spec regression test to assert that purely positive lanes leave the right side empty

## Testing
- python pythonProject/main.py --format JPN
- pytest tests/test_lane_spec_links.py


------
https://chatgpt.com/codex/tasks/task_e_68df1d2baf708327a4037fe0de26071f