### PR TITLE
Prevent lane_count heuristics from splitting single-side lanes

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -869,10 +869,12 @@ def build_lane_spec(
                     else:
                         derived_right.extend(unresolved)
 
+    # `derived_right` 仅代表算法在缺乏直接信息时的暂时推断。如果没有来自
+    # 编号或几何的右侧证据，就不应该因为之前的推断而放弃“全部保持在同一侧”
+    # 的兜底策略，否则会把单侧车道硬性拆成左右两组。
     final_no_right_evidence = (
         not negative_bases
         and not hinted_right
-        and not derived_right
         and not has_geometry_right_hint
     )
 

--- a/tests/test_lane_spec_links.py
+++ b/tests/test_lane_spec_links.py
@@ -196,7 +196,10 @@ def test_lane_spec_keeps_positive_lanes_on_default_side_without_right_evidence()
         },
     }
 
-    specs = build_lane_spec(sections, lane_topology, defaults={}, lane_div_df=None)
+    defaults = {"default_lane_side": "right"}
+    specs = build_lane_spec(
+        sections, lane_topology, defaults=defaults, lane_div_df=None
+    )
 
     assert len(specs) == 1
     section = specs[0]


### PR DESCRIPTION
## Summary
- stop treating heuristic right assignments as evidence when no right-side hints exist so single-side lanes remain grouped
- exercise the lane-count regression test with a right-hand-traffic default to cover the JPN scenario

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df223ee71483279ebde67f9eeac21c