### PR TITLE
Handle invalid Z samples in line geometry lookup

### DIFF
--- a/csv2xodr/line_geometry.py
+++ b/csv2xodr/line_geometry.py
@@ -104,12 +104,34 @@ def build_line_geometry_lookup(
         if lat_val is None or lon_val is None:
             continue
 
+        group_key = (
+            line_id,
+            row[logtime_col] if logtime_col else None,
+            row[instance_col] if instance_col else None,
+            row[flag_col] if flag_col else None,
+            row[type_col] if type_col else None,
+        )
+
+        entry = grouped.setdefault(
+            group_key,
+            {
+                "line_id": line_id,
+                "lat": [],
+                "lon": [],
+                "z": [],
+                "offset": [],
+                "has_true": False,
+                "has_false": False,
+                "has_flag": False,
+            },
+        )
+
         z_val = _to_float(row[z_col]) if z_col else None
         if z_val is not None:
             if not math.isfinite(z_val) or abs(z_val) >= 1e4:
                 z_val = None
         if z_val is None:
-            existing = entry.get("z", []) or []
+            existing = entry.get("z")
             if existing:
                 z_val = existing[-1]
             else:
@@ -174,28 +196,6 @@ def build_line_geometry_lookup(
             off_val = start_cm + step_val * index
         else:
             off_val = float(off_cm_raw)
-
-        group_key = (
-            line_id,
-            row[logtime_col] if logtime_col else None,
-            row[instance_col] if instance_col else None,
-            row[flag_col] if flag_col else None,
-            row[type_col] if type_col else None,
-        )
-
-        entry = grouped.setdefault(
-            group_key,
-            {
-                "line_id": line_id,
-                "lat": [],
-                "lon": [],
-                "z": [],
-                "offset": [],
-                "has_true": False,
-                "has_false": False,
-                "has_flag": False,
-            },
-        )
 
         retrans_flag = None
         if is_retrans_col is not None:

--- a/tests/test_line_geometry.py
+++ b/tests/test_line_geometry.py
@@ -183,6 +183,16 @@ def test_build_line_geometry_lookup_filters_height_outliers():
                 "Type": "1",
                 "Is Retransmission": "false",
             },
+            {
+                "ライン型地物ID": "50",
+                "Offset[cm]": "200",
+                "緯度[deg]": "35.00002",
+                "経度[deg]": "139.00002",
+                "高さ[m]": "55.5",
+                "ログ時刻": "base",
+                "Type": "1",
+                "Is Retransmission": "false",
+            },
         ]
     )
 
@@ -192,8 +202,10 @@ def test_build_line_geometry_lookup_filters_height_outliers():
 
     assert "50" in lookup
     geom = lookup["50"][0]
-    assert geom["z"][0] == pytest.approx(55.0)
-    assert geom["z"][1] == pytest.approx(55.0), "outlier heights should be clamped"
+    assert geom["s"] == pytest.approx([0.0, 1.0, 2.0])
+    assert geom["z"] == pytest.approx(
+        [55.0, 55.0, 55.5]
+    ), "outlier heights should be clamped while keeping continuity"
 
 
 def test_build_line_geometry_lookup_splits_when_offset_resets():


### PR DESCRIPTION
## Summary
- initialise line geometry group entries before height sanitisation and reuse the previous Z value when encountering invalid samples
- extend the height outlier test case to assert continuity when placeholder heights appear

## Testing
- pytest tests/test_line_geometry.py::test_build_line_geometry_lookup_filters_height_outliers

------
https://chatgpt.com/codex/tasks/task_e_68df28746104832791eba88365c117c6