### PR TITLE
Add explicit road mark geometry export

### DIFF
--- a/csv2xodr/writer/xodr_writer.py
+++ b/csv2xodr/writer/xodr_writer.py
@@ -178,6 +178,8 @@ def write_xodr(
         left_el = SubElement(ls, "left") if has_left else None
         right_el = SubElement(ls, "right") if has_right else None
 
+        section_s0 = float(sec["s0"])
+
         def _write_lane(parent, lane_data):
             lane_id = lane_data["id"]
             lane_type = lane_data.get("type", "driving")
@@ -205,7 +207,55 @@ def write_xodr(
                     "color": str(road_mark.get("color", "standard")),
                     "laneChange": str(road_mark.get("laneChange", "both")),
                 }
-                SubElement(ln, "roadMark", rm_attrs)
+                rm_el = SubElement(ln, "roadMark", rm_attrs)
+
+                geometry = None
+                if isinstance(road_mark, dict):
+                    geometry = road_mark.get("geometry")
+
+                if geometry:
+                    s_vals = geometry.get("s") or []
+                    x_vals = geometry.get("x") or []
+                    y_vals = geometry.get("y") or []
+                    z_vals = geometry.get("z") or []
+                    if (
+                        len(s_vals) == len(x_vals)
+                        and len(s_vals) == len(y_vals)
+                        and len(s_vals) == len(z_vals)
+                        and len(s_vals) >= 2
+                    ):
+                        explicit_el = SubElement(rm_el, "explicit")
+
+                        for idx in range(len(s_vals) - 1):
+                            try:
+                                s0 = float(s_vals[idx])
+                                x0 = float(x_vals[idx])
+                                x1 = float(x_vals[idx + 1])
+                                y0 = float(y_vals[idx])
+                                y1 = float(y_vals[idx + 1])
+                                z0 = float(z_vals[idx])
+                            except (TypeError, ValueError):
+                                continue
+
+                            length = math.hypot(x1 - x0, y1 - y0)
+                            if not math.isfinite(length) or length <= 1e-6:
+                                continue
+
+                            hdg = math.atan2(y1 - y0, x1 - x0)
+
+                            geom_attrs = {
+                                "sOffset": _format_float(s0 - section_s0, precision=12),
+                                "x": _format_float(x0, precision=12),
+                                "y": _format_float(y0, precision=12),
+                                "z": _format_float(z0, precision=12),
+                                "hdg": _format_float(hdg, precision=15),
+                                "length": _format_float(length, precision=12),
+                            }
+
+                            geom_el = SubElement(explicit_el, "geometry", geom_attrs)
+
+                            # Use a simple line primitive for consecutive polyline points.
+                            SubElement(geom_el, "line")
 
             predecessors = lane_data.get("predecessors") or []
             successors = lane_data.get("successors") or []


### PR DESCRIPTION
## Summary
- emit OpenDRIVE `<explicit>` geometry for lane road marks when the lane specification contains sampled polylines
- ensure lane-section aligned offsets and reuse of local coordinates when building geometry
- add a regression test that verifies `write_xodr` writes explicit road mark geometry

## Testing
- pytest tests/test_lane_spec_geometry.py

------
https://chatgpt.com/codex/tasks/task_e_68df2dd0f72883279f57a6ab36c9274a