### PR TITLE
Bump OpenDRIVE header version for explicit road mark geometry

### DIFF
--- a/csv2xodr/writer/xodr_writer.py
+++ b/csv2xodr/writer/xodr_writer.py
@@ -36,6 +36,7 @@ def write_xodr(
         "version": "1.00",
         "date": "2025-09-16",
     })
+    explicit_geometry_written = False
     if geo_ref:
         SubElement(header, "geoReference").text = geo_ref
 
@@ -181,6 +182,7 @@ def write_xodr(
         section_s0 = float(sec["s0"])
 
         def _write_lane(parent, lane_data):
+            nonlocal explicit_geometry_written
             lane_id = lane_data["id"]
             lane_type = lane_data.get("type", "driving")
             ln = SubElement(
@@ -224,6 +226,11 @@ def write_xodr(
                         and len(s_vals) == len(z_vals)
                         and len(s_vals) >= 2
                     ):
+                        if not explicit_geometry_written:
+                            explicit_geometry_written = True
+                            header.set("revMinor", "6")
+                            header.set("version", "1.06")
+
                         explicit_el = SubElement(rm_el, "explicit")
 
                         for idx in range(len(s_vals) - 1):

--- a/out/JPN/map.xodr
+++ b/out/JPN/map.xodr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <OpenDRIVE>
-  <header revMajor="1" revMinor="4" name="csv2xodr" version="1.00" date="2025-09-16">
+  <header revMajor="1" revMinor="6" name="csv2xodr" version="1.06" date="2025-09-16">
     <geoReference>LOCAL_XY origin=36.11478232688149,139.6358160999687</geoReference>
   </header>
   <road name="road_1" length="1370.883284862" id="1" junction="-1">

--- a/out/US/map.xodr
+++ b/out/US/map.xodr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <OpenDRIVE>
-  <header revMajor="1" revMinor="4" name="csv2xodr" version="1.00" date="2025-09-16">
+  <header revMajor="1" revMinor="6" name="csv2xodr" version="1.06" date="2025-09-16">
     <geoReference>LOCAL_XY origin=34.11419981953553,-117.97830875915902</geoReference>
   </header>
   <road name="road_1" length="1335.650721777" id="1" junction="-1">

--- a/tests/test_lane_spec_geometry.py
+++ b/tests/test_lane_spec_geometry.py
@@ -326,6 +326,11 @@ def test_write_xodr_emits_explicit_lane_mark_geometry(tmp_path):
     write_xodr(centerline, sections, lane_specs, out_file)
 
     root = ET.parse(out_file).getroot()
+    header = root.find("header")
+    assert header is not None
+    assert header.get("revMinor") == "6"
+    assert header.get("version") == "1.06"
+
     road_marks = root.findall(".//roadMark")
 
     assert len(road_marks) == 2


### PR DESCRIPTION
## Summary
- update the writer to bump the OpenDRIVE header to revision 1.6 whenever explicit roadMark geometry is written
- extend the explicit road-mark regression test to assert the bumped header revision and version
- refresh the sample OpenDRIVE outputs to reflect the new header metadata

## Testing
- pytest tests/test_lane_spec_geometry.py

------
https://chatgpt.com/codex/tasks/task_e_68df34d593f88327b5284aa0896cdc3e