### PR TITLE
Add curvature CSV interpolation utility

### DIFF
--- a/pythonProject/interpolate_curvature.py
+++ b/pythonProject/interpolate_curvature.py
@@ -1,0 +1,170 @@
+"""Utilities for interpolating missing curvature shape indices in CSV files."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Sequence
+
+SHAPE_INDEX_COLUMN = "形状インデックス"
+LANE_COUNT_COLUMN = "曲率情報のレーン数"
+DEFAULT_ENCODING = "cp932"
+
+# Columns that uniquely describe a lane segment.  Rows sharing the same values for
+# these fields are considered part of the same interpolation group.
+GROUP_KEY_COLUMNS: Sequence[str] = (
+    "logTime",
+    "Instance ID",
+    "Is Retransmission",
+    "Path Id",
+    "Offset[cm]",
+    "End Offset[cm]",
+    "Lane Number",
+    LANE_COUNT_COLUMN,
+)
+
+
+def _parse_int(value: str) -> int:
+    """Best-effort conversion of ``value`` to ``int``."""
+
+    value = (value or "").strip()
+    if not value:
+        raise ValueError("cannot parse empty value as int")
+    try:
+        return int(value)
+    except ValueError as exc:  # pragma: no cover - defensive fallback
+        raise ValueError(f"invalid integer value: {value!r}") from exc
+
+
+def _clone_with_index(row: Mapping[str, str], index: int) -> MutableMapping[str, str]:
+    clone = dict(row)
+    clone[SHAPE_INDEX_COLUMN] = str(index)
+    return clone
+
+
+def _group_rows(rows: Iterable[MutableMapping[str, str]]) -> Iterable[List[MutableMapping[str, str]]]:
+    """Yield consecutive groups of rows sharing the same lane descriptor."""
+
+    current_key: List[str] | None = None
+    current_group: List[MutableMapping[str, str]] = []
+
+    for row in rows:
+        key = [row.get(column, "") for column in GROUP_KEY_COLUMNS]
+        if current_key is None:
+            current_key = key
+        if key != current_key:
+            yield current_group
+            current_group = [row]
+            current_key = key
+        else:
+            current_group.append(row)
+
+    if current_group:
+        yield current_group
+
+
+def interpolate_group(rows: Sequence[MutableMapping[str, str]]) -> List[MutableMapping[str, str]]:
+    """Fill missing shape indices within ``rows`` belonging to the same lane."""
+
+    index_map: Dict[int, List[MutableMapping[str, str]]] = defaultdict(list)
+    for row in rows:
+        index_map[_parse_int(row[SHAPE_INDEX_COLUMN])].append(row)
+
+    if not index_map:
+        return [dict(row) for row in rows]
+
+    existing_indices = sorted(index_map)
+    max_index = existing_indices[-1]
+    interpolated: List[MutableMapping[str, str]] = []
+    last_templates: List[MutableMapping[str, str]] | None = None
+
+    for index in range(0, max_index + 1):
+        if index in index_map:
+            templates = [_clone_with_index(row, index) for row in index_map[index]]
+        else:
+            if last_templates is not None:
+                templates = [_clone_with_index(row, index) for row in last_templates]
+            else:
+                # Missing indices at the start should fall back to the next available data.
+                next_index = next(existing for existing in existing_indices if existing > index)
+                templates = [_clone_with_index(row, index) for row in index_map[next_index]]
+        interpolated.extend(templates)
+        last_templates = [dict(row) for row in templates]
+
+    return interpolated
+
+
+def interpolate_shape_indices(rows: Iterable[MutableMapping[str, str]]) -> List[MutableMapping[str, str]]:
+    """Interpolate missing shape indices across all lane groups."""
+
+    output: List[MutableMapping[str, str]] = []
+    for group in _group_rows(list(rows)):
+        output.extend(interpolate_group(group))
+    return output
+
+
+def process_file(path: Path, *, encoding: str = DEFAULT_ENCODING) -> int:
+    """Interpolate missing shape indices for ``path`` in place.
+
+    Returns the number of rows that were added during the interpolation.
+    """
+
+    with path.open("r", encoding=encoding, newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = list(reader.fieldnames or [])
+        rows = [dict(row) for row in reader]
+
+    updated_rows = interpolate_shape_indices(rows)
+    added_rows = len(updated_rows) - len(rows)
+
+    with path.open("w", encoding=encoding, newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(updated_rows)
+
+    return added_rows
+
+
+def _default_files(root: Path) -> List[Path]:
+    return [
+        root / "input_csv" / "JPN" / "PROFILETYPE_MPU_ZGM_CURVATURE.csv",
+        root / "input_csv" / "US" / "PROFILETYPE_MPU_US_CURVATURE.csv",
+    ]
+
+
+def _parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Interpolate missing CURVATURE.csv shape indices.")
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="CSV files to update. Defaults to the standard JPN/US curvature datasets.",
+    )
+    parser.add_argument(
+        "--encoding",
+        default=DEFAULT_ENCODING,
+        help="Character encoding used to read/write the CSV files (default: %(default)s).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_arguments()
+    files = args.files or _default_files(Path(__file__).resolve().parents[1])
+
+    for path in files:
+        if not path.exists():
+            print(f"[SKIP] {path} (not found)")
+            continue
+
+        added = process_file(path, encoding=args.encoding)
+        if added:
+            print(f"[OK] {path}: added {added} interpolated row(s)")
+        else:
+            print(f"[OK] {path}: no missing shape indices detected")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_curvature_interpolation.py
+++ b/tests/test_curvature_interpolation.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import csv
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from pythonProject.interpolate_curvature import (
+    SHAPE_INDEX_COLUMN,
+    interpolate_group,
+    interpolate_shape_indices,
+    process_file,
+)
+
+
+def _make_row(
+    *,
+    lane_id: str,
+    index: int,
+    lane_count: str = "2",
+    heading: str | None = None,
+    curvature: str | None = None,
+) -> dict[str, str]:
+    return {
+        "logTime": lane_id,
+        "Instance ID": lane_id,
+        "Is Retransmission": "False",
+        "Path Id": lane_id,
+        "Offset[cm]": lane_id,
+        "End Offset[cm]": lane_id,
+        "Lane Number": lane_id,
+        "曲率情報のレーン数": lane_count,
+        SHAPE_INDEX_COLUMN: str(index),
+        "方位角[deg]": heading or f"{100 + index:.1f}",
+        "曲率値[rad/m]": curvature or f"{index / 10:.4f}",
+        "精度情報": "65535",
+    }
+
+
+def test_interpolate_group_fills_internal_gaps_with_previous_values():
+    rows = [
+        _make_row(lane_id="A", index=0, heading="10.0", curvature="0.1000"),
+        _make_row(lane_id="A", index=2, heading="30.0", curvature="0.3000"),
+    ]
+
+    result = interpolate_group(rows)
+    indices = [int(row[SHAPE_INDEX_COLUMN]) for row in result]
+
+    assert indices == [0, 1, 2]
+    assert result[1]["方位角[deg]"] == "10.0"
+    assert result[1]["曲率値[rad/m]"] == "0.1000"
+
+
+def test_interpolate_group_uses_following_rows_when_initial_index_missing():
+    rows = [
+        _make_row(lane_id="B", index=1, heading="20.0", curvature="0.2000"),
+        _make_row(lane_id="B", index=1, heading="21.0", curvature="0.2100"),
+    ]
+
+    result = interpolate_group(rows)
+    indices = [int(row[SHAPE_INDEX_COLUMN]) for row in result]
+
+    assert indices == [0, 0, 1, 1]
+    assert result[0]["方位角[deg]"] == "20.0"
+    assert result[1]["方位角[deg]"] == "21.0"
+
+
+def test_interpolate_shape_indices_resets_between_lanes():
+    lane_a = [
+        _make_row(lane_id="A", index=0, heading="15.0"),
+        _make_row(lane_id="A", index=1, heading="25.0"),
+    ]
+    lane_b = [
+        _make_row(lane_id="B", index=2, heading="35.0"),
+    ]
+
+    result = interpolate_shape_indices(lane_a + lane_b)
+
+    a_indices = [int(row[SHAPE_INDEX_COLUMN]) for row in result[:2]]
+    b_indices = [int(row[SHAPE_INDEX_COLUMN]) for row in result[2:]]
+
+    assert a_indices == [0, 1]
+    assert b_indices == [0, 1, 2]
+    assert result[2]["方位角[deg]"] == "35.0"
+
+
+def test_process_file_updates_csv(tmp_path: Path):
+    source = tmp_path / "curvature.csv"
+    rows = [
+        _make_row(lane_id="C", index=1, heading="11.0"),
+        _make_row(lane_id="C", index=2, heading="12.0"),
+    ]
+
+    fieldnames = list(rows[0].keys())
+    with source.open("w", encoding="cp932", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    added = process_file(source, encoding="cp932")
+
+    with source.open("r", encoding="cp932", newline="") as handle:
+        reader = csv.DictReader(handle)
+        updated = list(reader)
+
+    assert added == 1
+    assert [int(row[SHAPE_INDEX_COLUMN]) for row in updated] == [0, 1, 2]
+    assert updated[0]["方位角[deg]"] == "11.0"


### PR DESCRIPTION
## Summary
- add a CLI utility that backfills missing curvature shape indices using previous lane data or the next available row when starting indices are absent
- add targeted unit tests covering interpolation behaviour and the in-place CSV update helper

## Testing
- pytest tests/test_curvature_interpolation.py

------
https://chatgpt.com/codex/tasks/task_e_68e4d7a3b4488327b88cf322bb59a8f8