### PR TITLE
Fix duplicate rows during curvature interpolation

### DIFF
--- a/tests/test_curvature_interpolation.py
+++ b/tests/test_curvature_interpolation.py
@@ -64,9 +64,8 @@ def test_interpolate_group_uses_following_rows_when_initial_index_missing():
     result = interpolate_group(rows)
     indices = [int(row[SHAPE_INDEX_COLUMN]) for row in result]
 
-    assert indices == [0, 0, 1, 1]
+    assert indices == [0, 1, 1]
     assert result[0]["方位角[deg]"] == "20.0"
-    assert result[1]["方位角[deg]"] == "21.0"
 
 
 def test_interpolate_shape_indices_resets_between_lanes():


### PR DESCRIPTION
## Summary
- prevent interpolate_curvature.py from duplicating every template row when backfilling missing shape indices
- remember only a single template row for future insertions so that each interpolated index adds at most one record
- update the curvature interpolation unit test expectations for the refined behaviour

## Testing
- pytest tests/test_curvature_interpolation.py

------
https://chatgpt.com/codex/tasks/task_e_68e5f2b4a46c832780ae7bb3916a804a