### PR TITLE
Fix US curvature import and lane topology filtering

### DIFF
--- a/csv2xodr/config_us.yaml
+++ b/csv2xodr/config_us.yaml
@@ -9,6 +9,7 @@ files:
   lane_link: PROFILETYPE_MPU_US_LANE_LINK_INFO.csv
   lane_division: PROFILETYPE_MPU_US_LANE_LINE.csv
   lane_width: PROFILETYPE_MPU_US_LANE_WIDTH.csv
+  curvature: PROFILETYPE_MPU_US_CURVATURE.csv
   slope: PROFILETYPE_MPU_US_SLOPE.csv
   sign: PROFILETYPE_MPU_US_SIGN.csv
 

--- a/csv2xodr/normalize/core.py
+++ b/csv2xodr/normalize/core.py
@@ -1794,7 +1794,7 @@ def build_geometry_segments(
         _record_best(segments, deviation)
 
     if deviation > max_endpoint_deviation:
-        if best_deviation <= max_endpoint_deviation:
+        if best_segments:
             return best_segments
         return []
 

--- a/csv2xodr/topology/core.py
+++ b/csv2xodr/topology/core.py
@@ -354,6 +354,9 @@ def build_lane_topology(lane_link_df: DataFrame,
             mapped_start = offset_mapper(mapped_start)
             mapped_end = offset_mapper(mapped_end)
 
+        if mapped_end - mapped_start <= 1e-6:
+            continue
+
         updated = dict(record)
         updated["start"] = mapped_start
         updated["end"] = mapped_end


### PR DESCRIPTION
## Summary
- load the US curvature CSV so plan view arcs can be generated instead of only polylines
- keep the best-fit arc approximation when curvature refinement cannot meet the tightened tolerance
- ignore lane link segments that collapse to zero length after mapping offsets to the centreline to avoid phantom lanes

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e5fc529d788327bb3b68cbfc644b89