### PR TITLE
Fix curvature fallback threshold in line geometry lookup

### DIFF
--- a/csv2xodr/line_geometry.py
+++ b/csv2xodr/line_geometry.py
@@ -137,6 +137,7 @@ def build_line_geometry_lookup(
                         best_curv = curv
 
         if best_curv is None:
+            best_dist_sq = float("inf")
             for sx, sy, curv in prepared_samples:
                 dist_sq = (sx - x_val) ** 2 + (sy - y_val) ** 2
                 if dist_sq < best_dist_sq:


### PR DESCRIPTION
## Summary
- reset the global search radius when falling back to the full curvature sample list
- allow lane-offset geometries to reuse curvature samples even when they are several metres away from the grid cell centre

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e60dbb43ac83279d726ece8e19d323