### PR TITLE
修复曲率映射并统一OpenDRIVE版本

### DIFF
--- a/csv2xodr/writer/xodr_writer.py
+++ b/csv2xodr/writer/xodr_writer.py
@@ -97,7 +97,7 @@ def write_xodr(
         "revMajor": "1",
         "revMinor": "4",
         "name": "csv2xodr",
-        "version": "1.00",
+        "version": "1.4",
         "date": "2025-09-16",
     })
     explicit_geometry_written = False


### PR DESCRIPTION
## Summary
- 使用形状索引与offset组合将曲率精确映射到白线几何，并在缺失时回退到空间搜索
- 增强CSV几何解析逻辑，记录路径/车道信息并提升曲率查找稳定性
- 将生成的OpenDRIVE头部版本改为1.4并补充针对曲率映射的单元测试

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e60cda1240832784a38e67c82b9a8d