### PR TITLE
Fix lane line geometry selection for overlapping IDs

### DIFF
--- a/csv2xodr/lane_spec.py
+++ b/csv2xodr/lane_spec.py
@@ -1205,9 +1205,27 @@ def build_lane_spec(
 
             pos_key = 2 if side == "left" else 1
             alt_key = 1 if side == "left" else 2
-            line_id = segment.get("line_positions", {}).get(pos_key)
-            if not line_id:
-                line_id = segment.get("line_positions", {}).get(alt_key)
+
+            line_positions = segment.get("line_positions", {}) or {}
+
+            def _iter_ids(*keys):
+                for key in keys:
+                    value = line_positions.get(key)
+                    if isinstance(value, (list, tuple)):
+                        for item in value:
+                            if item:
+                                yield item
+                    elif value:
+                        yield value
+
+            line_id = None
+            candidates = list(_iter_ids(pos_key, alt_key))
+            for candidate in candidates:
+                if division_lookup.get(candidate):
+                    line_id = candidate
+                    break
+            if line_id is None and candidates:
+                line_id = candidates[0]
 
             mark = None
             if line_id:

--- a/csv2xodr/topology/core.py
+++ b/csv2xodr/topology/core.py
@@ -300,7 +300,7 @@ def build_lane_topology(lane_link_df: DataFrame,
             if raw_add_remove and raw_add_remove not in {"0", ""}:
                 skip_lane = True
 
-        line_positions: Dict[int, str] = {}
+        line_positions: Dict[int, List[str]] = {}
         for idx, col in line_id_cols:
             lid = _canonical_numeric(row[col], allow_negative=True)
             if not lid or lid in {"-1"}:
@@ -313,8 +313,9 @@ def build_lane_topology(lane_link_df: DataFrame,
                 pos = None
             if pos is None:
                 continue
-            if pos not in line_positions:
-                line_positions[pos] = lid
+            bucket = line_positions.setdefault(pos, [])
+            if lid not in bucket:
+                bucket.append(lid)
 
         uid = _compose_lane_uid(base_id, lane_no)
         if skip_lane:


### PR DESCRIPTION
## Summary
- keep every lane line identifier reported for a position instead of discarding later entries when building the lane topology
- teach lane specification to consider all candidate lane line IDs and pick the first one that has division data, so white-line geometry attaches reliably

## Testing
- pytest
- python -m csv2xodr.csv2xodr --input input_csv/US --output out/us_fix.xodr --config csv2xodr/config_us.yaml
- python -m csv2xodr.csv2xodr --input input_csv/JPN --output out/jpn_fix.xodr --config csv2xodr/config.yaml


------
https://chatgpt.com/codex/tasks/task_e_68e6133ef3a083279676a1ad7d19497a