### PR TITLE
Align XODR output with OpenDRIVE 1.4H schema

### DIFF
--- a/pythonProject/convert_spiral_to_arc.py
+++ b/pythonProject/convert_spiral_to_arc.py
@@ -55,8 +55,11 @@ def convert_spiral_to_arc(path: Path) -> int:
             if element.tag != "spiral":
                 continue
 
-            curv_start = element.get("curvatureStart")
-            curv_end = element.get("curvatureEnd")
+            curv_start = element.get("curvStart")
+            curv_end = element.get("curvEnd")
+            if curv_start is None or curv_end is None:
+                curv_start = element.get("curvatureStart")
+                curv_end = element.get("curvatureEnd")
             if curv_start is None or curv_end is None:
                 print(
                     f"[WARN] 曲率情報が不足しているためスキップします: {path} (s={geometry.get('s', 'N/A')})",

--- a/pythonProject/generate_spiral_test_cases.py
+++ b/pythonProject/generate_spiral_test_cases.py
@@ -65,8 +65,8 @@ def _build_plan_view(parent: ET.Element, length: float, curvature_start: float, 
         geometry,
         "spiral",
         attrib={
-            "curvatureStart": f"{curvature_start:.12f}",
-            "curvatureEnd": f"{curvature_end:.12f}",
+            "curvStart": f"{curvature_start:.12f}",
+            "curvEnd": f"{curvature_end:.12f}",
         },
     )
 

--- a/tests/test_lane_spec_geometry.py
+++ b/tests/test_lane_spec_geometry.py
@@ -446,10 +446,10 @@ def test_write_xodr_emits_explicit_lane_mark_geometry(tmp_path):
     first = road_marks[0]
     explicit_first = first.find("explicit")
     assert explicit_first is not None
-    first_geoms = explicit_first.findall("geometry")
-    assert first_geoms
+    first_segments = list(explicit_first)
+    assert first_segments
 
-    attrs_first = first_geoms[0].attrib
+    attrs_first = first_segments[0].attrib
     assert float(attrs_first["sOffset"]) == pytest.approx(0.0)
     assert float(attrs_first["x"]) == pytest.approx(0.0)
     assert float(attrs_first["y"]) == pytest.approx(0.0)
@@ -459,8 +459,8 @@ def test_write_xodr_emits_explicit_lane_mark_geometry(tmp_path):
     last = road_marks[1]
     explicit_last = last.find("explicit")
     assert explicit_last is not None
-    last_geoms = explicit_last.findall("geometry")
-    assert len(last_geoms) == 2
-    assert float(last_geoms[0].attrib["sOffset"]) == pytest.approx(0.0)
-    assert float(last_geoms[0].attrib["x"]) == pytest.approx(4.0)
-    assert float(last_geoms[-1].attrib["x"]) == pytest.approx(5.0)
+    last_segments = list(explicit_last)
+    assert len(last_segments) == 2
+    assert float(last_segments[0].attrib["sOffset"]) == pytest.approx(0.0)
+    assert float(last_segments[0].attrib["x"]) == pytest.approx(4.0)
+    assert float(last_segments[-1].attrib["x"]) == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- update spiral planView output to use curvStart/curvEnd and emit signals after lanes as required by the schema
- restructure roadMark explicit geometry to write primitives directly (including <line>) instead of nested geometry blocks
- refresh supporting scripts and tests to understand the new attribute names

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69168e03211083278364cc65168bba26)